### PR TITLE
chore: release v2.0.0 — version bump + changelog + context-cost note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the enhanced edition of claude-code-docs will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [2.0.0] - 2026-07-31
 
 ### Breaking Changes — v1 *mirror* → v2 *manifest + client fetch*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the enhanced edition of claude-code-docs will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-07-31
 
 ### Breaking Changes — v1 *mirror* → v2 *manifest + client fetch*
 - **No documentation prose is committed anymore.** The repo now ships only metadata (`paths_manifest.json` + `search_index.json`); the actual `.md` pages are fetched at runtime from Anthropic's servers into a local cache at `~/.claude-code-docs/cache/`. See `ARCHITECTURE.md`.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-docs",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Searchable local index of Claude documentation. Provides the /docs command for instant access to API references, guides, and tutorials. Auto-discovery Skill reads docs automatically when you ask Claude-related questions. Docs auto-update via SessionStart hook.",
   "author": {
     "name": "costiash"

--- a/plugin/skills/claude-docs/SKILL.md
+++ b/plugin/skills/claude-docs/SKILL.md
@@ -82,8 +82,9 @@ A search returns a **filename** (e.g. `claude-code__hooks.md`). The file is at
 3. If the fetch fails (offline), the script prints the canonical source URL on stderr —
    fall back to WebFetch on that URL.
 
-To save context on large pages, you can preview a page's structure from the index
-(title + headings) before reading the full body:
+**To save context, prefer previewing large pages before reading them.** Pull a page's
+structure from the index (title + headings) first — often the headings alone answer the
+question and you skip loading a multi-KB body:
 ```bash
 jq -r '.pages[] | select(.filename=="<filename>") | .title, (.headings[]|"  "+.text)' ~/.claude-code-docs/search_index.json
 ```


### PR DESCRIPTION
## Phase F (non-tag) — release prep

The v1→v2 cutover is merged and live on `main` (metadata-only, no committed prose). This marks the version.

- **`plugin.json` 1.1.0 → 2.0.0** — the manifest + client-fetch rework is a breaking change (one-time re-sync on upgrade).
- **CHANGELOG** — promote the existing v2 `[Unreleased]` breaking-change entry to `[2.0.0] - 2026-07-31` (content unchanged).
- **`claude-docs/SKILL.md`** — recommend previewing large pages from the index (title + headings) before reading the full body, to save context (plan item F2).

### Deliberately NOT here
- **The `v2.0.0` git tag.** It must come *after* the Phase-D history purge — tagging now would point at soon-to-be-rewritten history, forcing a re-tag and changing the SHA for anyone who fetched it.

`marketplace.json` carries no version field (version lives only in `plugin.json`), so nothing to bump there. `claude plugin validate --strict` passes for both manifests.
