### PR TITLE
fix(ci): make the Claude review + @claude workflows actually work

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 15  # Prevent indefinite hanging
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write   # needed for `gh pr comment` to post the review
+      issues: write          # PR comments are issue comments
       id-token: write
 
     steps:
@@ -37,7 +37,6 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -57,5 +56,5 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write   # @claude needs to post/edit PR comments
+      issues: write          # ...and issue comments
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -39,6 +39,8 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+
+          claude_args: '--model claude-opus-4-8'
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
## Why

The `claude-review` check showed green on every PR but **never posted a review**. Investigation of run `30605243059` (PR #22):

```
result: is_error: true   num_turns: 1   total_cost_usd: 0   permission_denials_count: 0
gh pr comment was never run
```

Zero cost + one turn + immediate error = the **first Anthropic API call was rejected** — auth failure. The `CLAUDE_CODE_OAUTH_TOKEN` secret (last set **2025-11-03**) is expired, and `continue-on-error: true` painted the failure green. A second, latent bug: the job had `pull-requests: read` / `issues: read`, so `gh pr comment` (needs write) would 403 even with a valid token.

## Changes

- **`pull-requests` / `issues`: `read` → `write`** in both `claude-code-review.yml` and `claude.yml` (the `@claude` app has the same bug).
- **Drop `continue-on-error`** on the review step → a broken token/permission now fails the check **red** instead of a silent green.
- **Pin both bots to `--model claude-opus-4-8`.**

## Still needed (maintainer, not code)

**Refresh the token secret** — `claude setup-token`, then update **Settings → Secrets and variables → Actions → `CLAUDE_CODE_OAUTH_TOKEN`**. Until then the `claude-review` check will correctly go red (that's the point).

## Security note on the write grant

Safe within GitHub's model: `pull_request` runs from forks get a **read-only** token with **no secrets**, so `claude-code-review.yml` can't be prompt-injected from a fork (the action can't even auth). `claude.yml` (triggers on `@claude` mentions) relies on `claude-code-action`'s built-in **actor-permission gate** (it checks the commenter's repo permission before acting) — visible in the run logs as `Checking permissions for actor … Permission level retrieved`.
