### PR TITLE
docs(readme): surface the v2 model + upgrade note; cut filler (v2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Claude knows a lot — but documentation changes fast. API parameters shift, new
 | "I think the API works like..." | "According to the documentation..." |
 | You verify answers manually | Answers cite specific doc pages |
 
+## How It Works
+
+The repository commits **only metadata** — a page manifest and a prose-free search index (a couple of MB, no documentation text). Your machine fetches the actual `.md` pages from Anthropic's servers on demand into a local cache. So:
+
+- **Current** — answers come from the live page on `platform.claude.com` / `code.claude.com`, not a snapshot or stale training data.
+- **Private & compliant** — no Anthropic documentation is redistributed. The repo commits none of it (not at the tip, not in history); you fetch it yourself, straight from the source.
+- **Tiny** — the clone is a few MB of metadata, not the ~100 MB doc corpus, and pages are cached only as you open them.
+
 ## Quick Start — Plugin Install (Recommended)
 
 Two commands, no dependencies:
@@ -149,7 +157,7 @@ Claude recognizes this is a documentation question and automatically reads the r
 
 ## Documentation Coverage
 
-Documentation files across multiple categories, updated every 3 hours:
+The full Claude documentation set — every page on **platform.claude.com** and **code.claude.com** — re-indexed every 3 hours:
 
 - **API Reference** — Messages API, Admin API, multi-language SDKs (Python, TypeScript, Go, Java, Ruby, C#, PHP)
 - **Agent SDK** — Python and TypeScript SDK guides, sessions, hooks, custom tools
@@ -160,7 +168,6 @@ Documentation files across multiple categories, updated every 3 hours:
 - **Getting Started** — Quickstart guides
 - **Testing & Evaluation** — Eval frameworks, testing guides
 - **Release Notes** — Version history and changelogs
-- **Resources** — Additional resources
 
 ## How Updates Work
 
@@ -168,6 +175,8 @@ Documentation files across multiple categories, updated every 3 hours:
 2. **Automatic (CI/CD)** — GitHub Actions regenerates the manifest + index from Anthropic's `llms.txt` + sitemaps every 3 hours
 3. **On-Demand** — `/docs sync` fetches changed pages now; `/docs -t` checks freshness
 4. **Safe** — Manifest safeguards prevent catastrophic changes (min 200 pages discovered, max 10% removed per sync, min 250 pages)
+
+> **Upgrading from a v1 (mirror) install?** Nothing to do — your next session auto-migrates. The SessionStart hook hard-syncs to the metadata-only v2 layout (removing the old committed `docs/`, preserving your cache and courses), then fetches pages on demand.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## README polish for the v2.0.0 release

Honest audit conclusion: the README is strong and current — **not a rewrite**, targeted edits that surface the v2 story and cut filler.

### Changes
- **New "How It Works" nutshell** (up top) — the v2 differentiator was buried in one sentence: the repo ships only a manifest + prose-free index and the client fetches real pages on demand. Now stated as **Current / Private & compliant / Tiny**, which is the whole point of the 2.0.0 rework.
- **Reframed "Documentation Coverage" intro** — "Documentation files across multiple categories" → "The full Claude documentation set — every page on platform.claude.com and code.claude.com". (No hard page count, per the earlier decision to drop stale counts.)
- **Dropped filler** — the meaningless "Resources — Additional resources" bullet.
- **Added a v1→v2 upgrade note** — existing mirror installs auto-migrate on next session (hook `reset --hard`, cache preserved); nothing to do.

Left intentionally unchanged: the Why table, two-command Quick Start, the Courses showcase, Security, Troubleshooting, Team adoption — all accurate and effective.
