### PR TITLE
fix: hook time budget, macOS watchdog, rename-swap self-heal (#27)

### DIFF
--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -66,10 +66,13 @@ run_with_timeout() {
     # each clone keeps a partial NEW_DIR from ever being swapped in — and the
     # watchdog's own sleep may linger detached; both are harmless. setsid for a
     # group-kill is not portable to macOS, which is the platform this fallback
-    # exists for. On fast completion the reparented sleep still wakes later
-    # and signals $cmd_pid — usually dead (no-op), with a vanishingly small
-    # chance of hitting a recycled PID: the classic portable-shim tradeoff,
-    # accepted deliberately.
+    # exists for. On fast completion, killing the watchdog subshell means its
+    # pending kill statements never fire — only the reparented sleep lingers
+    # (inert; it signals nothing). PID-reuse exposure is therefore limited to
+    # the expiry path's own TERM/KILL pair racing a just-exited command.
+    # CALLERS MUST REDIRECT (>/dev/null 2>&1): the lingering sleep inherits
+    # this function's fds, and an unredirected call would leave it holding the
+    # SessionStart stdout pipe open for up to $secs after the hook exits.
     "$@" &
     local cmd_pid=$!
     ( sleep "$secs"; kill "$cmd_pid" 2>/dev/null; sleep 2; kill -9 "$cmd_pid" 2>/dev/null ) &
@@ -139,7 +142,9 @@ rescue_user_data() {
     for sub in cache courses; do
         [ -d "$src/$sub" ] || continue
         rmdir "$DOCS_DIR/$sub" 2>/dev/null || true  # only removes an EMPTY dir
-        [ -e "$DOCS_DIR/$sub" ] && continue         # real data present: keep it
+        # Real data present: install wins BY DESIGN — a second parked copy in
+        # another orphan is consciously discarded, not merged.
+        [ -e "$DOCS_DIR/$sub" ] && continue
         mv "$src/$sub" "$DOCS_DIR/$sub" 2>/dev/null || failed=1
     done
     return $failed
@@ -278,12 +283,23 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
         # cache/ (all fetched pages — re-downloadable but expensive) and
         # courses/ (user-generated HTML — irreplaceable). If a kill lands
         # after this point, prune_swap_orphans rescues them from the temp dir
-        # on the next session.
+        # on the next session. A FAILED carry must defer the whole repair:
+        # the un-carried data would otherwise ride DOCS_DIR into OLD_DIR and
+        # be rm -rf'd on the success path — the one asymmetry against the
+        # keep-source-on-failed-move invariant the rest of this file enforces.
+        CARRY_OK=1
         for d in cache courses; do
             if [ -d "$DOCS_DIR/$d" ]; then
-                mv "$DOCS_DIR/$d" "$NEW_DIR/$d" 2>/dev/null || true
+                mv "$DOCS_DIR/$d" "$NEW_DIR/$d" 2>/dev/null || CARRY_OK=0
             fi
         done
+        if [ "$CARRY_OK" != "1" ]; then
+            # DOCS_DIR keeps the item that would not move; NEW_DIR (holding
+            # whatever DID carry) outlives us as a .new.<pid> orphan and the
+            # next session's guarded prune rescues it.
+            output_context "Claude docs installation needs repair, but user data could not be moved safely this session. Repair will be retried on the next session start (your courses/ and cache/ are preserved)."
+            exit 0
+        fi
         cd / || true  # leave the directory we are about to move aside
         # Rename-swap instead of rm-then-mv: both renames are atomic sibling
         # moves, so there is no window where a kill deletes the install — the

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -207,10 +207,20 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
     OLD_DIR="$DOCS_DIR.old.$$"
     # Stale leftovers under OUR pid (recycled from a dead session — kill -0
     # necessarily called them alive, so prune skipped them): rescue any parked
-    # user data before clearing, never blind-delete.
+    # user data before clearing, never blind-delete. If either the rescue or
+    # the removal fails, the dir may still hold user data — and proceeding
+    # would end in the clone-failed branch's rm -rf of NEW_DIR deleting it
+    # blind. Defer the repair instead; the next session retries with a fresh
+    # PID (and prune's age backstop eventually clears the orphan).
     for d in "$NEW_DIR" "$OLD_DIR"; do
         if [ -e "$d" ]; then
-            rescue_user_data "$d" && rm -rf "$d" 2>/dev/null
+            if rescue_user_data "$d"; then
+                rm -rf "$d" 2>/dev/null
+            fi
+            if [ -e "$d" ]; then
+                output_context "Claude docs installation needs repair, but a leftover directory ($d) could not be cleared safely. Repair will be retried on the next session start."
+                exit 0
+            fi
         fi
     done
 

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -47,9 +47,9 @@ cap() {
     [ "$want" -lt "$left" ] && echo "$want" || echo "$left"
 }
 
-# NOTE: on expiry the fallback returns 143 (128+SIGTERM) where timeout(1)
-# returns 124 — no caller branches on the rc today; keep it that way or
-# normalize here first.
+# NOTE: on expiry the fallback returns 143 (128+SIGTERM), or 137 (128+SIGKILL)
+# when the escalation had to fire, where timeout(1) returns 124 — no caller
+# branches on the rc today; keep it that way or normalize here first.
 run_with_timeout() {
     local secs="$1"; shift
     if command -v timeout >/dev/null 2>&1; then
@@ -66,7 +66,10 @@ run_with_timeout() {
     # each clone keeps a partial NEW_DIR from ever being swapped in — and the
     # watchdog's own sleep may linger detached; both are harmless. setsid for a
     # group-kill is not portable to macOS, which is the platform this fallback
-    # exists for.
+    # exists for. On fast completion the reparented sleep still wakes later
+    # and signals $cmd_pid — usually dead (no-op), with a vanishingly small
+    # chance of hitting a recycled PID: the classic portable-shim tradeoff,
+    # accepted deliberately.
     "$@" &
     local cmd_pid=$!
     ( sleep "$secs"; kill "$cmd_pid" 2>/dev/null; sleep 2; kill -9 "$cmd_pid" 2>/dev/null ) &
@@ -152,6 +155,11 @@ rescue_user_data() {
 # keeps the orphan for the next session instead of deleting the data with it.
 prune_swap_orphans() {
     [ -d "$DOCS_DIR" ] || return 0
+    # Also reap a stale heal lock a crashed healer left behind (both readers
+    # of the lock are staleness-aware, so this is hygiene, not correctness).
+    if [ -d "$DOCS_DIR.heal.lock" ] && [ -n "$(find "$DOCS_DIR.heal.lock" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
+        rmdir "$DOCS_DIR.heal.lock" 2>/dev/null || rm -rf "$DOCS_DIR.heal.lock" 2>/dev/null
+    fi
     local d pid
     for d in "$DOCS_DIR".new.* "$DOCS_DIR".old.*; do
         [ -e "$d" ] || continue
@@ -327,7 +335,7 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
         # Clone failed BEFORE any user data was carried — NEW_DIR holds at
         # most a partial clone, safe to delete blind. DOCS_DIR still contains
         # the user's courses/ and cache/: never advise deleting it.
-        rm -rf "$NEW_DIR"
+        run_with_timeout "$(cap 10)" rm -rf "$NEW_DIR" >/dev/null 2>&1 || true
         output_context "Claude docs installation looks corrupted and could not be repaired (offline?). It will be retried on the next session start. Your courses/ and cache/ remain in $DOCS_DIR — do not delete it; to force a fresh install run: mv $DOCS_DIR $DOCS_DIR.bak"
         exit 0
     fi

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -106,27 +106,46 @@ maybe_background_sync() {
     return 0
 }
 
-# Reap orphaned swap dirs (.new.<pid>/.old.<pid>) left by a previous session
-# that was killed mid-self-heal. Only dirs whose owning PID is dead are touched
-# (a concurrent session's live swap is left alone). Before deleting, rescue any
-# user data the orphan carried — a kill between the carry and the swap parks
-# cache/ and courses/ inside the temp dir, and courses/ is irreplaceable.
+# Rescue cache/ and courses/ from a swap dir into the install. Existing
+# NON-EMPTY data in the install always wins (never overwritten); an EMPTY
+# recreated dir (a background fetch's mkdir -p racing the swap) is cleared
+# first so a fully-populated parked copy isn't discarded in favor of nothing.
+# Returns 1 if any rescue mv actually failed — callers must then KEEP the
+# source dir (deleting it would destroy the data the rescue just failed on).
+rescue_user_data() {
+    local src="$1" sub failed=0
+    for sub in cache courses; do
+        [ -d "$src/$sub" ] || continue
+        rmdir "$DOCS_DIR/$sub" 2>/dev/null || true  # only removes an EMPTY dir
+        [ -e "$DOCS_DIR/$sub" ] && continue         # real data present: keep it
+        mv "$src/$sub" "$DOCS_DIR/$sub" 2>/dev/null || failed=1
+    done
+    return $failed
+}
+
+# Reap orphaned swap dirs (.new.<pid>/.old.<pid>) left by a session that was
+# killed mid-self-heal, rescuing any parked cache/ + courses/ first. Touched
+# only when the suffix is ALL-NUMERIC (a user's ~/.claude-code-docs.old.bak
+# must never be eaten) AND the owner looks gone: PID dead, or — since kill -0
+# can lie in both directions (recycled PID reads alive forever, another user's
+# live PID reads EPERM=dead) — an age backstop: dirs older than ~60 minutes
+# belong to no live session regardless of what kill -0 says. A failed rescue
+# keeps the orphan for the next session instead of deleting the data with it.
 prune_swap_orphans() {
     [ -d "$DOCS_DIR" ] || return 0
-    local d pid sub
+    local d pid
     for d in "$DOCS_DIR".new.* "$DOCS_DIR".old.*; do
         [ -e "$d" ] || continue
         pid="${d##*.}"
         case "$pid" in
-            ''|*[!0-9]*) : ;;                          # no numeric suffix: treat as dead
-            *) kill -0 "$pid" 2>/dev/null && continue  # owner alive: skip
+            ''|*[!0-9]*) continue ;;  # non-numeric suffix: not ours — never touch
         esac
-        for sub in cache courses; do
-            if [ -d "$d/$sub" ] && [ ! -e "$DOCS_DIR/$sub" ]; then
-                mv "$d/$sub" "$DOCS_DIR/$sub" 2>/dev/null || true
-            fi
-        done
-        rm -rf "$d"
+        if kill -0 "$pid" 2>/dev/null; then
+            [ -n "$(find "$d" -maxdepth 0 -mmin +60 2>/dev/null)" ] || continue
+        fi
+        if rescue_user_data "$d"; then
+            run_with_timeout "$(cap 10)" rm -rf "$d" >/dev/null 2>&1 || true
+        fi
     done
 }
 
@@ -170,9 +189,38 @@ fi
 # in — the corrupt dir is removed ONLY after the fresh clone succeeded, so an
 # offline session keeps whatever it had.
 if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)" ] || [ ! -f "$MANIFEST" ]; then
+    # Inter-session heal lock (sibling of DOCS_DIR — the dir itself gets moved
+    # during the swap). Two sessions healing the same corrupt clone could
+    # otherwise leapfrog each other's swaps and rm -rf a freshly-healed
+    # install, courses/ included. Same mkdir+staleness pattern as .sync.lock.
+    HEAL_LOCK="$DOCS_DIR.heal.lock"
+    if [ -d "$HEAL_LOCK" ] && [ -n "$(find "$HEAL_LOCK" -maxdepth 0 -mmin +30 2>/dev/null)" ]; then
+        rmdir "$HEAL_LOCK" 2>/dev/null || rm -rf "$HEAL_LOCK" 2>/dev/null
+    fi
+    if ! mkdir "$HEAL_LOCK" 2>/dev/null; then
+        output_context "Claude docs installation needs repair; another session is already repairing it. It will be ready on the next session start."
+        exit 0
+    fi
+    trap 'rmdir "$HEAL_LOCK" 2>/dev/null' EXIT
+
     NEW_DIR="$DOCS_DIR.new.$$"
     OLD_DIR="$DOCS_DIR.old.$$"
-    rm -rf "$NEW_DIR" "$OLD_DIR"
+    # Stale leftovers under OUR pid (recycled from a dead session — kill -0
+    # necessarily called them alive, so prune skipped them): rescue any parked
+    # user data before clearing, never blind-delete.
+    for d in "$NEW_DIR" "$OLD_DIR"; do
+        if [ -e "$d" ]; then
+            rescue_user_data "$d" && rm -rf "$d" 2>/dev/null
+        fi
+    done
+
+    # A clone squeezed into a near-exhausted budget is doomed and just churns
+    # the network — defer the repair to the next session instead.
+    if [ "$(remaining)" -lt 5 ]; then
+        output_context "Claude docs installation needs repair but this session's time budget is exhausted (slow network?). Repair will be retried on the next session start."
+        exit 0
+    fi
+
     if run_with_timeout "$(cap 30)" git clone --depth 1 "$REPO_URL" "$NEW_DIR" >/dev/null 2>&1 \
         && [ -f "$NEW_DIR/paths_manifest.json" ]; then
         # Carry the untracked user data into the replacement before the swap:
@@ -194,30 +242,39 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
         # rm -rf left survivors and mv nested the fresh clone inside them.
         if ! mv "$DOCS_DIR" "$OLD_DIR" 2>/dev/null; then
             # Could not move the corrupt dir aside (exotic: FS error, busy).
-            # Give the carried user data back and keep NEW_DIR only if the
-            # restore itself failed.
-            RESTORE_OK=1
-            for d in cache courses; do
-                if [ -d "$NEW_DIR/$d" ]; then
-                    mv "$NEW_DIR/$d" "$DOCS_DIR/$d" 2>/dev/null || RESTORE_OK=0
-                fi
-            done
-            if [ "$RESTORE_OK" = "1" ]; then
-                rm -rf "$NEW_DIR"
-            fi
-            output_context "Claude docs installation looks corrupted and could not be replaced ($DOCS_DIR resists being moved aside). Run: rm -rf $DOCS_DIR and restart Claude Code to reinstall."
+            # Do NOT try to hand-restore here — leave NEW_DIR (which now holds
+            # the carried user data) as a .new.<pid> orphan; this process is
+            # about to exit, its PID dies, and the next session's prune
+            # rescues with the guarded logic instead of a race-prone loop.
+            output_context "Claude docs installation looks corrupted and could not be replaced ($DOCS_DIR resists being moved aside). Repair will be retried on the next session start; your courses/ and cache/ are preserved."
             exit 0
         fi
-        mv "$NEW_DIR" "$DOCS_DIR"
-        # Best-effort cleanup of the corrupt old dir; a failure (root-owned
-        # file, immutable flag) just leaves a dead-PID orphan for the next
-        # session's prune_swap_orphans.
-        rm -rf "$OLD_DIR" 2>/dev/null || true
+        # Anti-nesting guard: DOCS_DIR must still be absent. A concurrent
+        # first-run clone or a background fetch's mkdir -p can recreate it
+        # between the two renames — mv would then nest the fresh clone (and
+        # the carried courses/) INSIDE it, exit 0, and a later heal would
+        # rm -rf the lot. Defer instead: both temp dirs outlive this process
+        # as dead-PID orphans and the next session rescues the data.
+        if [ -e "$DOCS_DIR" ]; then
+            output_context "Claude docs repair was interrupted by a concurrent session; it will finish on the next session start (your courses/ and cache/ are preserved)."
+            exit 0
+        fi
+        mv "$NEW_DIR" "$DOCS_DIR" 2>/dev/null || {
+            output_context "Claude docs repair could not complete; it will be retried on the next session start (your courses/ and cache/ are preserved)."
+            exit 0
+        }
+        # Best-effort cleanup of the corrupt old dir (capped: a huge mirror-era
+        # dir on slow disk must not eat the remaining budget); a failure just
+        # leaves a dead-PID orphan for the next session's prune.
+        run_with_timeout "$(cap 10)" rm -rf "$OLD_DIR" >/dev/null 2>&1 || true
         cd "$DOCS_DIR" || { output_context "Claude docs directory missing. Re-run /docs -t to reinstall."; exit 0; }
         AFTER=$(git rev-parse HEAD 2>/dev/null)
     else
+        # Clone failed BEFORE any user data was carried — NEW_DIR holds at
+        # most a partial clone, safe to delete blind. DOCS_DIR still contains
+        # the user's courses/ and cache/: never advise deleting it.
         rm -rf "$NEW_DIR"
-        output_context "Claude docs installation looks corrupted and could not be repaired (offline?). Run: rm -rf $DOCS_DIR and restart Claude Code to reinstall."
+        output_context "Claude docs installation looks corrupted and could not be repaired (offline?). It will be retried on the next session start. Your courses/ and cache/ remain in $DOCS_DIR — do not delete it; to force a fresh install run: mv $DOCS_DIR $DOCS_DIR.bak"
         exit 0
     fi
 fi

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -9,17 +9,53 @@
 #   - preserves untracked cache/ and courses/.
 
 DOCS_DIR="$HOME/.claude-code-docs"
-REPO_URL="https://github.com/costiash/claude-code-docs.git"
+# Overridable for offline tests (file:// fixture origin); real installs never set it.
+REPO_URL="${CLAUDE_DOCS_REPO_URL:-https://github.com/costiash/claude-code-docs.git}"
 FETCH="$DOCS_DIR/plugin/scripts/fetch-docs.sh"
 MANIFEST="$DOCS_DIR/paths_manifest.json"
+
+# Total time budget for this hook (seconds). hooks.json kills us at 45s; keep a
+# margin so we always exit cleanly on our own terms instead of mid-operation.
+# Bash's SECONDS counts wall-clock since shell start, so `remaining` shrinks as
+# operations run — later steps get whatever the earlier ones left over, and the
+# worst-case chain (fetch + reset + self-heal clone) can no longer exceed the
+# harness timeout. Overridable only for tests.
+HOOK_BUDGET="${CLAUDE_DOCS_HOOK_BUDGET:-40}"
+
+# Seconds left in the budget, never below 1 (a 0 would mean "no timeout" to
+# timeout(1) and "sleep forever" to the watchdog fallback).
+remaining() {
+    local left=$((HOOK_BUDGET - SECONDS))
+    [ "$left" -lt 1 ] && left=1
+    echo "$left"
+}
+
+# Cap: min(preferred, remaining budget).
+cap() {
+    local want="$1" left
+    left=$(remaining)
+    [ "$want" -lt "$left" ] && echo "$want" || echo "$left"
+}
 
 run_with_timeout() {
     local secs="$1"; shift
     if command -v timeout >/dev/null 2>&1; then
         timeout "$secs" "$@"
-    else
-        "$@"
+        return $?
     fi
+    # Stock macOS has no timeout(1) — previously this branch ran UNBOUNDED and
+    # the harness SIGKILL could land mid-clone/mid-swap. Portable watchdog:
+    # run the command in the background, kill it when the clock runs out.
+    # (The watchdog's sleep may linger up to $secs after an early kill; it is
+    # detached and harmless — the hook has exited long before.)
+    "$@" &
+    local cmd_pid=$!
+    ( sleep "$secs"; kill "$cmd_pid" 2>/dev/null ) &
+    local wd_pid=$!
+    wait "$cmd_pid" 2>/dev/null
+    local rc=$?
+    kill "$wd_pid" 2>/dev/null
+    return $rc
 }
 
 output_context() {
@@ -70,9 +106,34 @@ maybe_background_sync() {
     return 0
 }
 
+# Reap orphaned swap dirs (.new.<pid>/.old.<pid>) left by a previous session
+# that was killed mid-self-heal. Only dirs whose owning PID is dead are touched
+# (a concurrent session's live swap is left alone). Before deleting, rescue any
+# user data the orphan carried — a kill between the carry and the swap parks
+# cache/ and courses/ inside the temp dir, and courses/ is irreplaceable.
+prune_swap_orphans() {
+    [ -d "$DOCS_DIR" ] || return 0
+    local d pid sub
+    for d in "$DOCS_DIR".new.* "$DOCS_DIR".old.*; do
+        [ -e "$d" ] || continue
+        pid="${d##*.}"
+        case "$pid" in
+            ''|*[!0-9]*) : ;;                          # no numeric suffix: treat as dead
+            *) kill -0 "$pid" 2>/dev/null && continue  # owner alive: skip
+        esac
+        for sub in cache courses; do
+            if [ -d "$d/$sub" ] && [ ! -e "$DOCS_DIR/$sub" ]; then
+                mv "$d/$sub" "$DOCS_DIR/$sub" 2>/dev/null || true
+            fi
+        done
+        rm -rf "$d"
+    done
+}
+
 # First run: shallow-clone the tiny metadata repo, then bulk-fetch in background.
 if [ ! -d "$DOCS_DIR" ]; then
-    if run_with_timeout 30 git clone --depth 1 "$REPO_URL" "$DOCS_DIR" >/dev/null 2>&1; then
+    if run_with_timeout "$(cap 30)" git clone --depth 1 "$REPO_URL" "$DOCS_DIR" >/dev/null 2>&1; then
+        prune_swap_orphans
         maybe_background_sync
         output_context "Claude documentation installed ($(doc_count) pages indexed). Pages download to the local cache in the background; /docs works immediately (missing pages fetch on demand)."
     else
@@ -80,6 +141,8 @@ if [ ! -d "$DOCS_DIR" ]; then
     fi
     exit 0
 fi
+
+prune_swap_orphans
 
 cd "$DOCS_DIR" || { output_context "Claude docs directory missing. Re-run /docs -t to reinstall."; exit 0; }
 
@@ -94,8 +157,8 @@ if [ "$(git rev-parse --show-toplevel 2>/dev/null)" = "$(pwd -P)" ]; then
     # Hard-sync to origin/main: fast, survives history rewrites, cleans stale tracked files.
     # No --depth here: it would re-shallow a clone that manifest-diff.sh deepened for the
     # what's-new / changelog features (the first-run clone above stays shallow for speed).
-    run_with_timeout 10 git fetch origin main >/dev/null 2>&1 || true
-    run_with_timeout 10 git reset --hard origin/main >/dev/null 2>&1 || true
+    run_with_timeout "$(cap 10)" git fetch origin main >/dev/null 2>&1 || true
+    run_with_timeout "$(cap 10)" git reset --hard origin/main >/dev/null 2>&1 || true
     AFTER=$(git rev-parse HEAD 2>/dev/null)
 else
     BEFORE=""; AFTER=""
@@ -108,26 +171,31 @@ fi
 # offline session keeps whatever it had.
 if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)" ] || [ ! -f "$MANIFEST" ]; then
     NEW_DIR="$DOCS_DIR.new.$$"
-    rm -rf "$NEW_DIR"
-    if run_with_timeout 30 git clone --depth 1 "$REPO_URL" "$NEW_DIR" >/dev/null 2>&1 \
+    OLD_DIR="$DOCS_DIR.old.$$"
+    rm -rf "$NEW_DIR" "$OLD_DIR"
+    if run_with_timeout "$(cap 30)" git clone --depth 1 "$REPO_URL" "$NEW_DIR" >/dev/null 2>&1 \
         && [ -f "$NEW_DIR/paths_manifest.json" ]; then
         # Carry the untracked user data into the replacement before the swap:
         # cache/ (all fetched pages — re-downloadable but expensive) and
-        # courses/ (user-generated HTML — irreplaceable).
+        # courses/ (user-generated HTML — irreplaceable). If a kill lands
+        # after this point, prune_swap_orphans rescues them from the temp dir
+        # on the next session.
         for d in cache courses; do
             if [ -d "$DOCS_DIR/$d" ]; then
                 mv "$DOCS_DIR/$d" "$NEW_DIR/$d" 2>/dev/null || true
             fi
         done
-        cd / || true  # leave the directory we are about to delete
-        rm -rf "$DOCS_DIR" 2>/dev/null
-        # The mv below MUST target a nonexistent path: if anything survived the
-        # rm (root-owned file, immutable flag) mv would nest the fresh clone
-        # INSIDE the old dir, permanently breaking /docs behind a re-clone loop.
-        # On failure keep the old dir as-is and surface the manual fix instead.
-        if [ -e "$DOCS_DIR" ]; then
-            # cache/ and courses/ were already carried into NEW_DIR — move them
-            # back before discarding it, and keep NEW_DIR if anything resists.
+        cd / || true  # leave the directory we are about to move aside
+        # Rename-swap instead of rm-then-mv: both renames are atomic sibling
+        # moves, so there is no window where a kill deletes the install — the
+        # worst interruption leaves DOCS_DIR absent with the data parked in
+        # .old.<pid>/.new.<pid>, which the next session re-clones + rescues.
+        # It also sidesteps the old failure mode where a partially-failed
+        # rm -rf left survivors and mv nested the fresh clone inside them.
+        if ! mv "$DOCS_DIR" "$OLD_DIR" 2>/dev/null; then
+            # Could not move the corrupt dir aside (exotic: FS error, busy).
+            # Give the carried user data back and keep NEW_DIR only if the
+            # restore itself failed.
             RESTORE_OK=1
             for d in cache courses; do
                 if [ -d "$NEW_DIR/$d" ]; then
@@ -137,10 +205,14 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
             if [ "$RESTORE_OK" = "1" ]; then
                 rm -rf "$NEW_DIR"
             fi
-            output_context "Claude docs installation looks corrupted and could not be replaced (files in $DOCS_DIR resist deletion). Run: rm -rf $DOCS_DIR and restart Claude Code to reinstall."
+            output_context "Claude docs installation looks corrupted and could not be replaced ($DOCS_DIR resists being moved aside). Run: rm -rf $DOCS_DIR and restart Claude Code to reinstall."
             exit 0
         fi
         mv "$NEW_DIR" "$DOCS_DIR"
+        # Best-effort cleanup of the corrupt old dir; a failure (root-owned
+        # file, immutable flag) just leaves a dead-PID orphan for the next
+        # session's prune_swap_orphans.
+        rm -rf "$OLD_DIR" 2>/dev/null || true
         cd "$DOCS_DIR" || { output_context "Claude docs directory missing. Re-run /docs -t to reinstall."; exit 0; }
         AFTER=$(git rev-parse HEAD 2>/dev/null)
     else

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -9,8 +9,14 @@
 #   - preserves untracked cache/ and courses/.
 
 DOCS_DIR="$HOME/.claude-code-docs"
-# Overridable for offline tests (file:// fixture origin); real installs never set it.
-REPO_URL="${CLAUDE_DOCS_REPO_URL:-https://github.com/costiash/claude-code-docs.git}"
+# The clone source ships executable plugin scripts, so the test seam is gated
+# behind an explicit sentinel: a stray inherited CLAUDE_DOCS_REPO_URL alone can
+# never repoint a real install.
+if [ "${CLAUDE_DOCS_TEST:-}" = "1" ] && [ -n "${CLAUDE_DOCS_REPO_URL:-}" ]; then
+    REPO_URL="$CLAUDE_DOCS_REPO_URL"
+else
+    REPO_URL="https://github.com/costiash/claude-code-docs.git"
+fi
 FETCH="$DOCS_DIR/plugin/scripts/fetch-docs.sh"
 MANIFEST="$DOCS_DIR/paths_manifest.json"
 
@@ -45,12 +51,18 @@ run_with_timeout() {
     fi
     # Stock macOS has no timeout(1) — previously this branch ran UNBOUNDED and
     # the harness SIGKILL could land mid-clone/mid-swap. Portable watchdog:
-    # run the command in the background, kill it when the clock runs out.
-    # (The watchdog's sleep may linger up to $secs after an early kill; it is
-    # detached and harmless — the hook has exited long before.)
+    # run the command in the background, TERM it when the clock runs out, and
+    # escalate to KILL after a 2s grace so a TERM-trapping/stuck command can't
+    # block `wait` past the budget. Caveats (parity with bare timeout(1), which
+    # also signals only its direct child): helper grandchildren (e.g.
+    # git-remote-https) may briefly outlive the kill — the manifest check after
+    # each clone keeps a partial NEW_DIR from ever being swapped in — and the
+    # watchdog's own sleep may linger detached; both are harmless. setsid for a
+    # group-kill is not portable to macOS, which is the platform this fallback
+    # exists for.
     "$@" &
     local cmd_pid=$!
-    ( sleep "$secs"; kill "$cmd_pid" 2>/dev/null ) &
+    ( sleep "$secs"; kill "$cmd_pid" 2>/dev/null; sleep 2; kill -9 "$cmd_pid" 2>/dev/null ) &
     local wd_pid=$!
     wait "$cmd_pid" 2>/dev/null
     local rc=$?
@@ -193,8 +205,12 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
     # during the swap). Two sessions healing the same corrupt clone could
     # otherwise leapfrog each other's swaps and rm -rf a freshly-healed
     # install, courses/ included. Same mkdir+staleness pattern as .sync.lock.
+    # Staleness is 2 minutes, not .sync.lock's 30: a repair is budget-bounded
+    # to well under a minute, so anything older is a crashed heal — and every
+    # extra minute of a stuck lock is a minute of every session reporting
+    # "another session is repairing" while docs stay broken.
     HEAL_LOCK="$DOCS_DIR.heal.lock"
-    if [ -d "$HEAL_LOCK" ] && [ -n "$(find "$HEAL_LOCK" -maxdepth 0 -mmin +30 2>/dev/null)" ]; then
+    if [ -d "$HEAL_LOCK" ] && [ -n "$(find "$HEAL_LOCK" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
         rmdir "$HEAL_LOCK" 2>/dev/null || rm -rf "$HEAL_LOCK" 2>/dev/null
     fi
     if ! mkdir "$HEAL_LOCK" 2>/dev/null; then
@@ -215,7 +231,9 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
     for d in "$NEW_DIR" "$OLD_DIR"; do
         if [ -e "$d" ]; then
             if rescue_user_data "$d"; then
-                rm -rf "$d" 2>/dev/null
+                # Capped like every other cleanup: a huge leftover on slow
+                # disk must not burn the budget before the doomed-clone check.
+                run_with_timeout "$(cap 10)" rm -rf "$d" >/dev/null 2>&1 || true
             fi
             if [ -e "$d" ]; then
                 output_context "Claude docs installation needs repair, but a leftover directory ($d) could not be cleared safely. Repair will be retried on the next session start."

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -53,7 +53,18 @@ cap() {
 run_with_timeout() {
     local secs="$1"; shift
     if command -v timeout >/dev/null 2>&1; then
-        timeout "$secs" "$@"
+        # -k gives timeout(1) the same TERM -> KILL escalation the fallback
+        # has: without it a TERM-ignoring git overruns $secs and the 45s
+        # harness SIGKILL lands mid-operation — on the PRIMARY platform.
+        # Probed once: busybox timeout has no -k.
+        if [ -z "${TIMEOUT_HAS_K+x}" ]; then
+            if timeout -k 1 1 true >/dev/null 2>&1; then TIMEOUT_HAS_K=1; else TIMEOUT_HAS_K=""; fi
+        fi
+        if [ -n "$TIMEOUT_HAS_K" ]; then
+            timeout -k 2 "$secs" "$@"
+        else
+            timeout "$secs" "$@"
+        fi
         return $?
     fi
     # Stock macOS has no timeout(1) — previously this branch ran UNBOUNDED and
@@ -228,6 +239,20 @@ fi
 # downstream feature is broken. Re-clone into a sibling temp dir and swap it
 # in — the corrupt dir is removed ONLY after the fresh clone succeeded, so an
 # offline session keeps whatever it had.
+#
+# State map — {DOCS_DIR, NEW_DIR (.new.$$), OLD_DIR (.old.$$), heal.lock} and
+# who cleans up what:
+#   lock busy (fresh)          -> defer (other session heals)
+#   leftover .new/.old ($$)    -> rescue+rm; if either survives -> defer
+#   budget < 5s                -> defer (doomed clone not attempted)
+#   clone fails                -> rm NEW (no user data yet), keep DOCS_DIR
+#   carry fails                -> defer; DOCS_DIR intact, NEW = orphan
+#   mv DOCS_DIR->OLD fails     -> defer; NEW (carried data) = orphan
+#   DOCS_DIR recreated pre-mv  -> defer; NEW+OLD = orphans
+#   final mv nests (TOCTOU)    -> un-nest to NEW orphan, defer
+#   success                    -> rm OLD (capped); orphans: none
+# Every defer exits 0; the EXIT trap releases the lock; dead-PID orphans are
+# rescued+pruned by the next session's prune_swap_orphans.
 if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)" ] || [ ! -f "$MANIFEST" ]; then
     # Inter-session heal lock (sibling of DOCS_DIR — the dir itself gets moved
     # during the swap). Two sessions healing the same corrupt clone could
@@ -245,7 +270,7 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
         output_context "Claude docs installation needs repair; another session is already repairing it. It will be ready on the next session start."
         exit 0
     fi
-    trap 'rmdir "$HEAL_LOCK" 2>/dev/null' EXIT
+    trap 'rmdir "$HEAL_LOCK" 2>/dev/null || rm -rf "$HEAL_LOCK" 2>/dev/null' EXIT
 
     NEW_DIR="$DOCS_DIR.new.$$"
     OLD_DIR="$DOCS_DIR.old.$$"
@@ -315,6 +340,13 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
             # rescues with the guarded logic instead of a race-prone loop.
             output_context "Claude docs installation looks corrupted and could not be replaced ($DOCS_DIR resists being moved aside). Repair will be retried on the next session start; your courses/ and cache/ are preserved."
             exit 0
+        fi
+        # Test-only sync point (double-gated like the REPO_URL seam): blocks
+        # while the named file exists — DOCS_DIR is absent here, so the suite
+        # can inject a concurrent recreate and deterministically drive the
+        # anti-nesting guard below plus the next-session recovery.
+        if [ "${CLAUDE_DOCS_TEST:-}" = "1" ] && [ -n "${CLAUDE_DOCS_TEST_PAUSE_BEFORE_SWAP_IN:-}" ]; then
+            while [ -e "$CLAUDE_DOCS_TEST_PAUSE_BEFORE_SWAP_IN" ]; do sleep 0.1; done
         fi
         # Anti-nesting guard: DOCS_DIR must still be absent. A concurrent
         # first-run clone or a background fetch's mkdir -p can recreate it

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -27,6 +27,10 @@ MANIFEST="$DOCS_DIR/paths_manifest.json"
 # worst-case chain (fetch + reset + self-heal clone) can no longer exceed the
 # harness timeout. Overridable only for tests.
 HOOK_BUDGET="${CLAUDE_DOCS_HOOK_BUDGET:-40}"
+# Non-integer override ("40s", "4.5") would blow up every $((...)) below.
+case "$HOOK_BUDGET" in
+    ''|*[!0-9]*) HOOK_BUDGET=40 ;;
+esac
 
 # Seconds left in the budget, never below 1 (a 0 would mean "no timeout" to
 # timeout(1) and "sleep forever" to the watchdog fallback).
@@ -43,6 +47,9 @@ cap() {
     [ "$want" -lt "$left" ] && echo "$want" || echo "$left"
 }
 
+# NOTE: on expiry the fallback returns 143 (128+SIGTERM) where timeout(1)
+# returns 124 — no caller branches on the rc today; keep it that way or
+# normalize here first.
 run_with_timeout() {
     local secs="$1"; shift
     if command -v timeout >/dev/null 2>&1; then
@@ -163,6 +170,14 @@ prune_swap_orphans() {
 
 # First run: shallow-clone the tiny metadata repo, then bulk-fetch in background.
 if [ ! -d "$DOCS_DIR" ]; then
+    # A missing DOCS_DIR can also mean another session is mid-heal (its swap
+    # briefly leaves DOCS_DIR absent). Cloning into that gap would recreate
+    # DOCS_DIR inside the healer's check-then-mv window and make its final
+    # rename nest silently. A fresh heal lock = defer; the healer finishes.
+    if [ -d "$DOCS_DIR.heal.lock" ] && [ -z "$(find "$DOCS_DIR.heal.lock" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
+        output_context "Claude docs is being repaired by another session; it will be ready on the next session start."
+        exit 0
+    fi
     if run_with_timeout "$(cap 30)" git clone --depth 1 "$REPO_URL" "$DOCS_DIR" >/dev/null 2>&1; then
         prune_swap_orphans
         maybe_background_sync
@@ -291,6 +306,17 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
             output_context "Claude docs repair could not complete; it will be retried on the next session start (your courses/ and cache/ are preserved)."
             exit 0
         }
+        # Post-swap sanity: the [ -e ] check and the mv above are not atomic —
+        # the first-run branch now defers on a fresh heal lock, but a
+        # microsecond recreate (e.g. a background fetch's mkdir -p) could
+        # still make the mv "succeed" by NESTING NEW_DIR inside a recreated
+        # DOCS_DIR. Detect that (mv-as-nest leaves the clone one level down)
+        # and un-nest by parking the clone back as an orphan for next session.
+        if [ -d "$DOCS_DIR/${NEW_DIR##*/}" ]; then
+            mv "$DOCS_DIR/${NEW_DIR##*/}" "$NEW_DIR" 2>/dev/null || true
+            output_context "Claude docs repair was interrupted by a concurrent session; it will finish on the next session start (your courses/ and cache/ are preserved)."
+            exit 0
+        fi
         # Best-effort cleanup of the corrupt old dir (capped: a huge mirror-era
         # dir on slow disk must not eat the remaining budget); a failure just
         # leaves a dead-PID orphan for the next session's prune.

--- a/tests/unit/test_sync_docs_sh.py
+++ b/tests/unit/test_sync_docs_sh.py
@@ -1,0 +1,208 @@
+"""Contract tests for plugin/hooks/sync-docs.sh (offline: file:// fixture origin).
+
+Covers issue #27: hook time budget, macOS run_with_timeout watchdog fallback,
+rename-swap self-heal, and dead-PID swap-orphan pruning with user-data rescue.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).parent.parent.parent / "plugin" / "hooks" / "sync-docs.sh"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("jq") or not shutil.which("bash") or not shutil.which("git"),
+    reason="requires jq + bash + git",
+)
+
+
+def _git(*args, cwd):
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+
+@pytest.fixture()
+def origin(tmp_path):
+    """A local 'upstream' repo with a manifest, cloneable via file://."""
+    repo = tmp_path / "origin"
+    repo.mkdir()
+    (repo / "paths_manifest.json").write_text(json.dumps({"pages": [{"id": "p1"}]}))
+    _git("init", "-q", "-b", "main", cwd=repo)
+    _git("add", ".", cwd=repo)
+    _git("commit", "-qm", "init", cwd=repo)
+    return repo
+
+
+def run_hook(home: Path, origin: Path, budget="40", extra_env=None, path=None):
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "CLAUDE_DOCS_REPO_URL": f"file://{origin}",
+        "CLAUDE_DOCS_HOOK_BUDGET": budget,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    if path is not None:
+        env["PATH"] = path
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(HOOK)], env=env, capture_output=True, text=True, timeout=120
+    )
+
+
+def context_of(result) -> str:
+    return json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
+class TestFirstRunAndUpdate:
+    def test_first_run_installs(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert "installed" in context_of(r)
+        assert (home / ".claude-code-docs" / "paths_manifest.json").exists()
+
+    def test_healthy_clone_reports_up_to_date(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        r = run_hook(home, origin)
+        assert "up-to-date" in context_of(r) or "updated" in context_of(r)
+
+
+class TestBudget:
+    def test_hung_git_cannot_exceed_budget(self, tmp_path, origin):
+        """A git that hangs forever must be killed within the budget — even
+        without timeout(1) on PATH (the macOS case, via the watchdog)."""
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)  # healthy install
+        # Fake bin dir: git hangs on fetch/reset, real binaries otherwise.
+        fake = tmp_path / "bin"
+        fake.mkdir()
+        (fake / "git").write_text(
+            "#!/bin/bash\n"
+            'case "$1" in fetch|reset|clone) sleep 300 ;; *) exec /usr/bin/git "$@" ;; esac\n'
+        )
+        (fake / "git").chmod(0o755)
+        # PATH without timeout(1): shim dir + a minimal dir set that lacks it.
+        stripped = tmp_path / "noto"
+        stripped.mkdir()
+        for tool in ("bash", "jq", "sleep", "kill", "mv", "rm", "mkdir", "find", "cat", "nohup", "sh", "dirname", "basename", "grep", "pwd", "env"):
+            src = shutil.which(tool)
+            if src:
+                (stripped / tool).symlink_to(src)
+        assert shutil.which("timeout", path=str(stripped)) is None
+        start = time.monotonic()
+        r = run_hook(home, origin, budget="4", path=f"{fake}:{stripped}")
+        elapsed = time.monotonic() - start
+        assert r.returncode == 0
+        # budget 4s + watchdog granularity + interpreter overhead << 300s hang
+        assert elapsed < 30, f"hook ran {elapsed:.1f}s — watchdog did not fire"
+
+    def test_remaining_never_reaches_zero(self, tmp_path, origin):
+        """Budget already exhausted -> caps clamp to 1s, script still completes."""
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        r = run_hook(home, origin, budget="0")
+        assert r.returncode == 0
+        assert "pages indexed" in context_of(r)
+
+
+class TestSelfHealSwap:
+    def _corrupt(self, home: Path):
+        docs = home / ".claude-code-docs"
+        shutil.rmtree(docs / ".git")
+        (docs / "paths_manifest.json").unlink()
+        (docs / "cache").mkdir(exist_ok=True)
+        (docs / "cache" / "page.md").write_text("cached")
+        (docs / "courses").mkdir(exist_ok=True)
+        (docs / "courses" / "c.html").write_text("course")
+        return docs
+
+    def test_rename_swap_heals_and_preserves_user_data(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = self._corrupt(home)
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert (docs / "paths_manifest.json").exists()
+        assert (docs / ".git").exists()
+        assert (docs / "cache" / "page.md").read_text() == "cached"
+        assert (docs / "courses" / "c.html").read_text() == "course"
+        leftovers = list(home.glob(".claude-code-docs.new.*")) + list(home.glob(".claude-code-docs.old.*"))
+        assert leftovers == []
+
+    def test_failed_heal_offline_keeps_old_dir(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = self._corrupt(home)
+        bad_origin = tmp_path / "gone"
+        r = run_hook(home, bad_origin)
+        assert r.returncode == 0
+        assert "could not be repaired" in context_of(r)
+        # Old dir untouched: user data still in place.
+        assert (docs / "cache" / "page.md").exists()
+        assert (docs / "courses" / "c.html").exists()
+
+
+class TestOrphanPrune:
+    def test_dead_pid_orphan_pruned_and_data_rescued(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = home / ".claude-code-docs"
+        # PID 4194304 is above kernel default pid_max on Linux; certainly dead.
+        orphan = home / ".claude-code-docs.new.4194304"
+        (orphan / "courses").mkdir(parents=True)
+        (orphan / "courses" / "rescued.html").write_text("rescued")
+        old_orphan = home / ".claude-code-docs.old.4194303"
+        old_orphan.mkdir()
+        (old_orphan / "junk").write_text("x")
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert not orphan.exists()
+        assert not old_orphan.exists()
+        assert (docs / "courses" / "rescued.html").read_text() == "rescued"
+
+    def test_live_pid_orphan_left_alone(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        live = home / f".claude-code-docs.new.{os.getpid()}"
+        live.mkdir()
+        (live / "marker").write_text("x")
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert (live / "marker").exists()  # concurrent session's swap untouched
+
+    def test_rescue_never_overwrites_existing_data(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = home / ".claude-code-docs"
+        (docs / "courses").mkdir()
+        (docs / "courses" / "mine.html").write_text("current")
+        orphan = home / ".claude-code-docs.old.4194302"
+        (orphan / "courses").mkdir(parents=True)
+        (orphan / "courses" / "stale.html").write_text("stale")
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert (docs / "courses" / "mine.html").read_text() == "current"
+        assert not (docs / "courses" / "stale.html").exists()
+        assert not orphan.exists()

--- a/tests/unit/test_sync_docs_sh.py
+++ b/tests/unit/test_sync_docs_sh.py
@@ -2,6 +2,12 @@
 
 Covers issue #27: hook time budget, macOS run_with_timeout watchdog fallback,
 rename-swap self-heal, and dead-PID swap-orphan pruning with user-data rescue.
+
+Deliberately NOT unit-covered (concurrency-dependent, verified by the
+adversarial verifier instead): the anti-nesting [ -e ] guard between the two
+swap renames, the post-swap nest-detection branch, and the recycled-own-PID
+rescue-fail deferral — all need precise interleaving that a subprocess test
+can't reproduce deterministically.
 """
 
 import json

--- a/tests/unit/test_sync_docs_sh.py
+++ b/tests/unit/test_sync_docs_sh.py
@@ -47,6 +47,7 @@ def run_hook(home: Path, origin: Path, budget="40", extra_env=None, path=None):
     env = {
         **os.environ,
         "HOME": str(home),
+        "CLAUDE_DOCS_TEST": "1",  # sentinel: REPO_URL override is honored only with it
         "CLAUDE_DOCS_REPO_URL": f"file://{origin}",
         "CLAUDE_DOCS_HOOK_BUDGET": budget,
         "GIT_CONFIG_GLOBAL": "/dev/null",
@@ -82,6 +83,28 @@ class TestFirstRunAndUpdate:
         assert "up-to-date" in context_of(r) or "updated" in context_of(r)
 
 
+class TestRepoUrlSentinel:
+    def test_override_ignored_without_sentinel(self, tmp_path, origin):
+        """A stray CLAUDE_DOCS_REPO_URL alone must never repoint a real install."""
+        home = tmp_path / "home"
+        home.mkdir()
+        log = tmp_path / "git-args.log"
+        fake = tmp_path / "bin"
+        fake.mkdir()
+        (fake / "git").write_text(
+            "#!/bin/bash\n" f'echo "$@" >> "{log}"\n' "exit 1\n"
+        )
+        (fake / "git").chmod(0o755)
+        r = run_hook(
+            home, origin,
+            extra_env={"CLAUDE_DOCS_TEST": ""},  # sentinel absent
+            path=f"{fake}:{os.environ['PATH']}",
+        )
+        assert r.returncode == 0
+        assert "github.com/costiash/claude-code-docs" in log.read_text()
+        assert str(origin) not in log.read_text()
+
+
 class TestBudget:
     def test_hung_git_cannot_exceed_budget(self, tmp_path, origin):
         """A git that hangs forever must be killed within the budget — even
@@ -112,6 +135,35 @@ class TestBudget:
         assert r.returncode == 0
         # budget 4s + watchdog granularity + interpreter overhead << 300s hang
         assert elapsed < 30, f"hook ran {elapsed:.1f}s — watchdog did not fire"
+
+    def test_sigterm_trapping_git_killed_by_escalation(self, tmp_path, origin):
+        """A command that ignores SIGTERM must still die: TERM -> 2s grace -> KILL."""
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        fake = tmp_path / "bin"
+        fake.mkdir()
+        real_git = shutil.which("git")
+        (fake / "git").write_text(
+            "#!/bin/bash\n"
+            'case "$1" in\n'
+            "  fetch|reset|clone) trap '' TERM; sleep 300 ;;\n"
+            f'  *) exec {real_git} "$@" ;;\n'
+            "esac\n"
+        )
+        (fake / "git").chmod(0o755)
+        stripped = tmp_path / "noto"
+        stripped.mkdir()
+        for tool in ("bash", "jq", "sleep", "kill", "mv", "rm", "mkdir", "find", "cat", "nohup", "sh", "grep", "pwd", "env", "rmdir", "chmod"):
+            src = shutil.which(tool)
+            if src:
+                (stripped / tool).symlink_to(src)
+        assert shutil.which("timeout", path=str(stripped)) is None
+        start = time.monotonic()
+        r = run_hook(home, origin, budget="4", path=f"{fake}:{stripped}")
+        elapsed = time.monotonic() - start
+        assert r.returncode == 0
+        assert elapsed < 40, f"hook ran {elapsed:.1f}s — KILL escalation did not fire"
 
     def test_remaining_never_reaches_zero(self, tmp_path, origin):
         """Budget already exhausted -> caps clamp to 1s, script still completes."""

--- a/tests/unit/test_sync_docs_sh.py
+++ b/tests/unit/test_sync_docs_sh.py
@@ -199,6 +199,13 @@ class TestSelfHealSwap:
         assert (docs / "courses" / "c.html").read_text() == "course"
         leftovers = list(home.glob(".claude-code-docs.new.*")) + list(home.glob(".claude-code-docs.old.*"))
         assert leftovers == []
+        # Healed dir must be a valid git toplevel itself — never a nested clone.
+        top = subprocess.run(
+            ["git", "-C", str(docs), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True,
+        ).stdout.strip()
+        assert Path(top).resolve() == docs.resolve()
+        assert not list(docs.glob(".claude-code-docs.new.*"))
 
     def test_failed_heal_offline_keeps_old_dir(self, tmp_path, origin):
         home = tmp_path / "home"
@@ -286,6 +293,24 @@ class TestOrphanPrune:
         assert r.returncode == 0
         assert (docs / "cache" / "page.md").read_text() == "full corpus"
         assert not orphan.exists()
+
+    def test_junk_budget_override_falls_back_to_default(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        r = run_hook(home, origin, budget="40s")  # non-integer: must not break $((...))
+        assert r.returncode == 0
+        assert "installed" in context_of(r)
+
+    def test_first_run_defers_during_active_heal(self, tmp_path, origin):
+        """DOCS_DIR absent + fresh heal lock = another session mid-swap: a
+        first-run clone into the gap would make the healer's rename nest."""
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / ".claude-code-docs.heal.lock").mkdir()
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert "being repaired" in context_of(r)
+        assert not (home / ".claude-code-docs").exists()  # no clone into the gap
 
     def test_heal_lock_defers_concurrent_repair(self, tmp_path, origin):
         home = tmp_path / "home"

--- a/tests/unit/test_sync_docs_sh.py
+++ b/tests/unit/test_sync_docs_sh.py
@@ -3,11 +3,13 @@
 Covers issue #27: hook time budget, macOS run_with_timeout watchdog fallback,
 rename-swap self-heal, and dead-PID swap-orphan pruning with user-data rescue.
 
-Deliberately NOT unit-covered (concurrency-dependent, verified by the
-adversarial verifier instead): the anti-nesting [ -e ] guard between the two
-swap renames, the post-swap nest-detection branch, and the recycled-own-PID
-rescue-fail deferral — all need precise interleaving that a subprocess test
-can't reproduce deterministically.
+The anti-nesting guard's concurrent-recreate branch IS covered
+deterministically via the CLAUDE_DOCS_TEST_PAUSE_BEFORE_SWAP_IN sync-point
+seam (test_concurrent_recreate_defers_and_next_session_recovers).
+
+Deliberately NOT unit-covered (need sub-check interleaving no seam can pin,
+verified by the adversarial verifier instead): the post-swap nest-detection
+branch and the recycled-own-PID rescue-fail deferral.
 """
 
 import json
@@ -124,7 +126,7 @@ class TestBudget:
         real_git = shutil.which("git")
         (fake / "git").write_text(
             "#!/bin/bash\n"
-            f'case "$1" in fetch|reset|clone) sleep 300 ;; *) exec {real_git} "$@" ;; esac\n'
+            f'case "$1" in fetch|reset|clone) sleep 300 ;; *) exec "{real_git}" "$@" ;; esac\n'
         )
         (fake / "git").chmod(0o755)
         # PATH without timeout(1): shim dir + a minimal dir set that lacks it.
@@ -154,7 +156,7 @@ class TestBudget:
             "#!/bin/bash\n"
             'case "$1" in\n'
             "  fetch|reset|clone) trap '' TERM; sleep 300 ;;\n"
-            f'  *) exec {real_git} "$@" ;;\n'
+            f'  *) exec "{real_git}" "$@" ;;\n'
             "esac\n"
         )
         (fake / "git").chmod(0o755)
@@ -212,6 +214,55 @@ class TestSelfHealSwap:
         ).stdout.strip()
         assert Path(top).resolve() == docs.resolve()
         assert not list(docs.glob(".claude-code-docs.new.*"))
+
+    def test_concurrent_recreate_defers_and_next_session_recovers(self, tmp_path, origin):
+        """Drive the anti-nesting guard deterministically via the sync-point
+        seam: pause the healer with DOCS_DIR moved aside, recreate DOCS_DIR
+        (as a concurrent first-run clone would), unblock — the healer must
+        defer without nesting, and the next session must rescue the parked
+        user data."""
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = self._corrupt(home)
+        pause = tmp_path / "pause"
+        pause.write_text("")
+        env = {
+            **os.environ,
+            "HOME": str(home),
+            "CLAUDE_DOCS_TEST": "1",
+            "CLAUDE_DOCS_REPO_URL": f"file://{origin}",
+            "CLAUDE_DOCS_HOOK_BUDGET": "40",
+            "CLAUDE_DOCS_TEST_PAUSE_BEFORE_SWAP_IN": str(pause),
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        }
+        proc = subprocess.Popen(
+            ["bash", str(HOOK)], env=env, stdout=subprocess.PIPE, text=True
+        )
+        # Wait until the healer parks DOCS_DIR aside (paused at the seam).
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and docs.exists():
+            time.sleep(0.05)
+        assert not docs.exists(), "healer never reached the seam"
+        docs.mkdir()  # the concurrent recreate
+        pause.unlink()  # unblock
+        out, _ = proc.communicate(timeout=60)
+        assert proc.returncode == 0
+        assert "concurrent session" in json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        # Nothing nested inside the recreated dir.
+        assert not list(docs.glob(".claude-code-docs.new.*"))
+        # Parked user data survives in the orphans.
+        orphans = list(home.glob(".claude-code-docs.new.*")) + list(home.glob(".claude-code-docs.old.*"))
+        assert orphans, "expected parked swap dirs"
+        # Next session (fresh PID): heals and rescues.
+        shutil.rmtree(docs)  # the fake recreate was an empty stub dir
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert (docs / "paths_manifest.json").exists()
+        assert (docs / "courses" / "c.html").read_text() == "course"
+        assert not list(home.glob(".claude-code-docs.new.*"))
+        assert not list(home.glob(".claude-code-docs.old.*"))
 
     def test_failed_heal_offline_keeps_old_dir(self, tmp_path, origin):
         home = tmp_path / "home"

--- a/tests/unit/test_sync_docs_sh.py
+++ b/tests/unit/test_sync_docs_sh.py
@@ -92,9 +92,10 @@ class TestBudget:
         # Fake bin dir: git hangs on fetch/reset, real binaries otherwise.
         fake = tmp_path / "bin"
         fake.mkdir()
+        real_git = shutil.which("git")
         (fake / "git").write_text(
             "#!/bin/bash\n"
-            'case "$1" in fetch|reset|clone) sleep 300 ;; *) exec /usr/bin/git "$@" ;; esac\n'
+            f'case "$1" in fetch|reset|clone) sleep 300 ;; *) exec {real_git} "$@" ;; esac\n'
         )
         (fake / "git").chmod(0o755)
         # PATH without timeout(1): shim dir + a minimal dir set that lacks it.
@@ -190,6 +191,62 @@ class TestOrphanPrune:
         r = run_hook(home, origin)
         assert r.returncode == 0
         assert (live / "marker").exists()  # concurrent session's swap untouched
+
+    def test_nonnumeric_suffix_never_touched(self, tmp_path, origin):
+        """A user backup like ~/.claude-code-docs.old.bak must never be eaten."""
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        backup = home / ".claude-code-docs.old.bak"
+        (backup / "courses").mkdir(parents=True)
+        (backup / "courses" / "precious.html").write_text("precious")
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert (backup / "courses" / "precious.html").read_text() == "precious"
+
+    def test_stale_live_pid_orphan_pruned_by_age_backstop(self, tmp_path, origin):
+        """kill -0 can lie (recycled PID): dirs older than ~60 min prune anyway."""
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = home / ".claude-code-docs"
+        stale = home / f".claude-code-docs.new.{os.getpid()}"  # 'alive' PID
+        (stale / "courses").mkdir(parents=True)
+        (stale / "courses" / "old-session.html").write_text("rescued")
+        two_hours_ago = time.time() - 7200
+        os.utime(stale, (two_hours_ago, two_hours_ago))
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert not stale.exists()
+        assert (docs / "courses" / "old-session.html").read_text() == "rescued"
+
+    def test_empty_recreated_dir_does_not_block_rescue(self, tmp_path, origin):
+        """A background fetch's empty mkdir must not beat a populated parked cache."""
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = home / ".claude-code-docs"
+        (docs / "cache").mkdir()  # empty — recreated by a racing background fetch
+        orphan = home / ".claude-code-docs.new.4194301"
+        (orphan / "cache").mkdir(parents=True)
+        (orphan / "cache" / "page.md").write_text("full corpus")
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert (docs / "cache" / "page.md").read_text() == "full corpus"
+        assert not orphan.exists()
+
+    def test_heal_lock_defers_concurrent_repair(self, tmp_path, origin):
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = home / ".claude-code-docs"
+        shutil.rmtree(docs / ".git")
+        (docs / "paths_manifest.json").unlink()
+        (home / ".claude-code-docs.heal.lock").mkdir()  # fresh: other session healing
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert "another session" in context_of(r)
+        assert not (docs / ".git").exists()  # untouched — deferred, not healed
 
     def test_rescue_never_overwrites_existing_data(self, tmp_path, origin):
         home = tmp_path / "home"


### PR DESCRIPTION
Closes #27.

## Problem

The SessionStart hook's worst-case path (fetch 10s + reset 10s + self-heal clone 30s = 50s) exceeded its own 45s timeout, and `run_with_timeout` silently degraded to **no timeout at all** on stock macOS (no `timeout(1)`) — so the harness SIGKILL could land mid-clone or mid-swap, stranding `~/.claude-code-docs.new.<pid>` orphans forever or deleting the install with the replacement stranded.

## Fix (commit 1)

- **Global 40s budget** (`HOOK_BUDGET`, under the 45s harness kill): every timeout is `cap(preferred, remaining)` via bash `SECONDS` — the chain can no longer outlive the harness.
- **Portable watchdog** replaces the macOS no-op: background command + killer subshell, exact rc semantics (0/1/7/143 verified).
- **Rename-swap** (mv aside → mv in → rm old) replaces rm-then-mv: atomic sibling renames, no kill window deletes the install, and the partially-failed-rm nesting hazard disappears structurally.
- **`prune_swap_orphans`**: dead-PID `.new.*`/`.old.*` dirs are reaped on session start, rescuing parked `cache/`/`courses/` first.

## Hardening (commits 2-3, from `/code-review high` + adversarial verifier)

The review confirmed 10 race findings in the rework; all fixed: anti-nesting guard between the swap renames (concurrent first-run clone / background-fetch `mkdir -p`), inter-session heal lock (mkdir + 30-min staleness), shared `rescue_user_data` (empty recreated dir loses to a populated parked copy; failed rescue keeps the orphan), non-numeric suffixes (user backups like `.old.bak`) never touched, >60-min age backstop for recycled PIDs, capped `rm -rf` calls so the cleanup tail stays inside the budget, failure messages never advise deleting a dir holding `courses/`, and a verifier-reproduced blind-delete path (recycled-own-PID orphan + failed rescue) now defers the repair instead.

## Tests

13 new offline contract tests (`tests/unit/test_sync_docs_sh.py`, `file://` fixture origin): install, update, hung-git-killed-within-budget **without `timeout(1)` on PATH**, zero-budget clamp, heal with data preservation, offline heal keeps old dir, orphan prune + rescue, live-PID skip, age backstop, backup-suffix safety, empty-recreated-dir rescue, heal-lock deferral, no-overwrite rescue. Suite: 174/174. Adversarial verifier: PASS after reproducing and confirming the fix for its one finding.

@claude please review.