### PR TITLE
fix: sync lock covers every caller; evidence-based reap; owner-checked release (#28)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,7 @@ as a clean start, not a mass removal. `update-docs.yml` repeats the floor check 
   `raw.githubusercontent.com`); atomic tmp+mv writes; retry-once; `xargs -P 8`.
   Offline + cache miss → the canonical URL is printed to stderr for a WebFetch fallback.
   `sync` is single-flight per cache via a PID-owned lock at `cache/.sync.lock/`
-  (owner PID in `pid`, mtime heartbeated per batch) — every caller is covered,
+  (owner PID in `pid`, mtime heartbeated per full fetch batch) — every caller is covered,
   hook or direct CLI. A held lock is reaped only on evidence: dead owner PID,
   a pidless lock older than a minute, or a 30-minute-idle mtime despite a
   "live" PID (recycled-PID backstop). Release is owner-checked, so a reaped

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,6 +104,12 @@ as a clean start, not a mass removal. `update-docs.yml` repeats the floor check 
   every run. Per-URL **domain allowlist** (`code.claude.com`, `platform.claude.com`,
   `raw.githubusercontent.com`); atomic tmp+mv writes; retry-once; `xargs -P 8`.
   Offline + cache miss → the canonical URL is printed to stderr for a WebFetch fallback.
+  `sync` is single-flight per cache via a PID-owned lock at `cache/.sync.lock/`
+  (owner PID in `pid`, mtime heartbeated per batch) — every caller is covered,
+  hook or direct CLI. A held lock is reaped only on evidence: dead owner PID,
+  a pidless lock older than a minute, or a 30-minute-idle mtime despite a
+  "live" PID (recycled-PID backstop). Release is owner-checked, so a reaped
+  and re-acquired lock is never removed by the previous owner.
 - **`manifest-diff.sh`** — `--since 7d|24h|<date>` diffs committed manifest revisions →
   Added / Changed / Removed (Changed keyed off `sha256`). Powers the three
   git-history-dependent features: what's-new, freshness, and the changelog report.
@@ -119,7 +125,8 @@ as a clean start, not a mass removal. `update-docs.yml` repeats the floor check 
 ├── search_index.json
 ├── plugin/…
 ├── cache/                      # fetched .md pages (gitignored, not in the repo)
-│   └── .meta/<filename>.json   # per-page sync sidecars
+│   ├── .meta/<filename>.json   # per-page sync sidecars
+│   └── .sync.lock/pid          # transient single-flight sync lock (owner PID)
 └── courses/                    # generated HTML (untracked, survives resets)
 ```
 

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -160,7 +160,7 @@ rescue_user_data() {
         # heuristic below, or a populated parked corpus gets discarded in
         # favor of an effectively-empty cache. Real content (.md pages,
         # sidecar files) makes the rmdir fail and the install win as before.
-        # ponytail: two narrow races, both crash-cleanup-only and benign:
+        # Known ceiling — two narrow races, both crash-cleanup-only and benign:
         # removing a contender's live lock at worst duplicates one sync
         # (atomic per-file writes); and a sync that acquired but has not yet
         # written any page can have its scaffold-only cache swapped for the

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -128,7 +128,8 @@ doc_count() {
 # 0-fetch fast path, so an already-current cache just no-ops in the background.
 # Concurrency control lives inside `fetch-docs.sh sync` itself (issue #28: a
 # PID-owned lock in the cache dir covers EVERY caller, not just this hook), so
-# the child is a cheap no-op when another session is already syncing. The
+# the child is a cheap no-op when another session is already syncing — the
+# unconditional fork per session is deliberate, not a missing gate. The
 # hook-era lock at $DOCS_DIR/.sync.lock is legacy — remove it so a dir left by
 # a crashed pre-#28 session doesn't linger forever (bare dir, rmdir suffices).
 maybe_background_sync() {

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -126,19 +126,15 @@ doc_count() {
 # foreground `status` scan: status is O(pages) and a large cache blew the 5s timeout
 # (exit 124, not 2), silently stranding pending updates. `sync` has its own cheap
 # 0-fetch fast path, so an already-current cache just no-ops in the background.
-# A lock dir prevents concurrent sessions from stacking parallel syncs; the worst
-# case of losing the mkdir race is a skipped sync (the next session retries).
+# Concurrency control lives inside `fetch-docs.sh sync` itself (issue #28: a
+# PID-owned lock in the cache dir covers EVERY caller, not just this hook), so
+# the child is a cheap no-op when another session is already syncing. The
+# hook-era lock at $DOCS_DIR/.sync.lock is legacy — remove it so a dir left by
+# a crashed pre-#28 session doesn't linger forever (bare dir, rmdir suffices).
 maybe_background_sync() {
     [ -x "$FETCH" ] || return 1
-    local lock="$DOCS_DIR/.sync.lock"
-    # Stale lock (a crashed sync never removed it): clear if older than ~30 minutes.
-    if [ -d "$lock" ] && [ -n "$(find "$lock" -maxdepth 0 -mmin +30 2>/dev/null)" ]; then
-        rmdir "$lock" 2>/dev/null || rm -rf "$lock" 2>/dev/null
-    fi
-    mkdir "$lock" 2>/dev/null || return 1  # another sync is running (or just won the race)
-    # The child owns the lock and removes it when the fetch finishes, however it exits.
-    nohup bash -c 'trap '\''rmdir "$2" 2>/dev/null'\'' EXIT; "$1" sync >/dev/null 2>&1' \
-        sync-docs-lock "$FETCH" "$lock" >/dev/null 2>&1 &
+    rmdir "$DOCS_DIR/.sync.lock" 2>/dev/null || true
+    nohup "$FETCH" sync >/dev/null 2>&1 &
     return 0
 }
 

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -133,7 +133,13 @@ doc_count() {
 # a crashed pre-#28 session doesn't linger forever (bare dir, rmdir suffices).
 maybe_background_sync() {
     [ -x "$FETCH" ] || return 1
-    rmdir "$DOCS_DIR/.sync.lock" 2>/dev/null || true
+    # Stale-only: a FRESH legacy lock can still belong to a live pre-#28
+    # session's sync child (which took no other lock) — blind removal would
+    # double-sync during the one-time upgrade window.
+    if [ -d "$DOCS_DIR/.sync.lock" ] \
+        && [ -n "$(find "$DOCS_DIR/.sync.lock" -maxdepth 0 -mmin +30 2>/dev/null)" ]; then
+        rmdir "$DOCS_DIR/.sync.lock" 2>/dev/null || true
+    fi
     nohup "$FETCH" sync >/dev/null 2>&1 &
     return 0
 }
@@ -148,6 +154,18 @@ rescue_user_data() {
     local src="$1" sub failed=0
     for sub in cache courses; do
         [ -d "$src/$sub" ] || continue
+        # A racing sync child recreates cache/ with scaffolding — an empty
+        # .meta/ (ensure_dirs) and possibly a .sync.lock/ — never bare-empty.
+        # Scaffolding is disposable and must not defeat the empty-dir
+        # heuristic below, or a populated parked corpus gets discarded in
+        # favor of an effectively-empty cache. Real content (.md pages,
+        # sidecar files) makes the rmdir fail and the install win as before.
+        # ponytail: removing a contender's live lock here at worst duplicates
+        # one sync (atomic per-file writes); rescue runs only on crash cleanup.
+        if [ "$sub" = "cache" ] && [ -d "$DOCS_DIR/$sub" ]; then
+            rmdir "$DOCS_DIR/$sub/.meta" 2>/dev/null || true  # empty .meta only
+            rm -rf "$DOCS_DIR/$sub/.sync.lock" 2>/dev/null || true
+        fi
         rmdir "$DOCS_DIR/$sub" 2>/dev/null || true  # only removes an EMPTY dir
         # Real data present: install wins BY DESIGN — a second parked copy in
         # another orphan is consciously discarded, not merged.
@@ -253,9 +271,10 @@ if [ "$(git -C "$DOCS_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)
     # Inter-session heal lock (sibling of DOCS_DIR — the dir itself gets moved
     # during the swap). Two sessions healing the same corrupt clone could
     # otherwise leapfrog each other's swaps and rm -rf a freshly-healed
-    # install, courses/ included. Same mkdir+staleness pattern as .sync.lock.
-    # Staleness is 2 minutes, not .sync.lock's 30: a repair is budget-bounded
-    # to well under a minute, so anything older is a crashed heal — and every
+    # install, courses/ included. Blind 2-minute mtime staleness is fine HERE
+    # (unlike the sync lock, now PID-owned in fetch-docs.sh, issue #28): a
+    # repair is budget-bounded to well under a minute, so anything older is a
+    # crashed heal — and every
     # extra minute of a stuck lock is a minute of every session reporting
     # "another session is repairing" while docs stay broken.
     HEAL_LOCK="$DOCS_DIR.heal.lock"

--- a/plugin/hooks/sync-docs.sh
+++ b/plugin/hooks/sync-docs.sh
@@ -160,8 +160,12 @@ rescue_user_data() {
         # heuristic below, or a populated parked corpus gets discarded in
         # favor of an effectively-empty cache. Real content (.md pages,
         # sidecar files) makes the rmdir fail and the install win as before.
-        # ponytail: removing a contender's live lock here at worst duplicates
-        # one sync (atomic per-file writes); rescue runs only on crash cleanup.
+        # ponytail: two narrow races, both crash-cleanup-only and benign:
+        # removing a contender's live lock at worst duplicates one sync
+        # (atomic per-file writes); and a sync that acquired but has not yet
+        # written any page can have its scaffold-only cache swapped for the
+        # rescued corpus mid-run — its children then write into the rescued
+        # cache, which is exactly where the pages belong.
         if [ "$sub" = "cache" ] && [ -d "$DOCS_DIR/$sub" ]; then
             rmdir "$DOCS_DIR/$sub/.meta" 2>/dev/null || true  # empty .meta only
             rm -rf "$DOCS_DIR/$sub/.sync.lock" 2>/dev/null || true

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -94,7 +94,9 @@ SYNC_LOCK_HELD=0
 release_sync_lock() {
     [ "$SYNC_LOCK_HELD" = 1 ] || return 0
     # Remove only a lock we still own: if a reaper replaced it, rmdir'ing the
-    # successor's lock here is exactly the #28 cascade.
+    # successor's lock here is exactly the #28 cascade. The cat->rm gap is a
+    # benign TOCTOU: worst case a reaper moved the dir aside between the two
+    # and the rm removes nothing.
     if [ "$(cat "$LOCK_DIR/pid" 2>/dev/null)" = "$$" ]; then
         rm -rf "$LOCK_DIR"
     fi
@@ -167,6 +169,9 @@ acquire_sync_lock() {
         # (fractional sleep is non-POSIX; fall back to a whole second).
         sleep 0.1 2>/dev/null || sleep 1
     done
+    # Spin-cap exhausted: reported as contention (rc 1) deliberately — ten
+    # failed rounds means someone keeps holding/recreating the lock, and
+    # the next sync attempt retries from scratch anyway.
     return 1
 }
 
@@ -326,8 +331,9 @@ cmd_sync() {
         if [ "$running" -ge "$PARALLEL" ]; then
             wait
             running=0
-            # Heartbeat (each FULL batch; the final partial batch goes
-            # without, bounded by --max-time far below the 30-min backstop)
+            # Heartbeat (each FULL batch; the final partial batch — including
+            # a whole sync that fits in one batch — goes without, bounded by
+            # --max-time far below the 30-min backstop)
             # for the recycled-PID reap. Dir-guarded: after a lock removal
             # races us, an unguarded touch would recreate the path as a
             # plain FILE and poison future acquisitions.

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -113,8 +113,12 @@ acquire_sync_lock() {
                 # never pass release's cat-guard and invites a live-owner
                 # reap after a minute — back out. Distinct rc: this is an
                 # error, not contention, and the caller must not report it
-                # as "another sync is already running".
-                rm -rf "$LOCK_DIR"
+                # as "another sync is already running". rmdir first: BSD
+                # rm -rf refuses an unreadable (e.g. umask-created 000) dir,
+                # while rmdir needs only parent perms; chmod is the belt for
+                # the non-empty ENOSPC case.
+                rmdir "$LOCK_DIR" 2>/dev/null \
+                    || { chmod -R u+rwx "$LOCK_DIR" 2>/dev/null; rm -rf "$LOCK_DIR"; }
                 return 2
             fi
             SYNC_LOCK_HELD=1
@@ -154,7 +158,10 @@ acquire_sync_lock() {
         # microsecond TOCTOU; worst case is one duplicate sync writing
         # atomically to the same cache, not corruption or lock loss.
         if mv "$LOCK_DIR" "$LOCK_DIR.reap.$$" 2>/dev/null; then
-            rm -rf "$LOCK_DIR.reap.$$"
+            # Same BSD-rm caveat as the backout: make the moved-aside lock
+            # readable before recursing so an unreadable dir can't litter.
+            rmdir "$LOCK_DIR.reap.$$" 2>/dev/null \
+                || { chmod -R u+rwx "$LOCK_DIR.reap.$$" 2>/dev/null; rm -rf "$LOCK_DIR.reap.$$"; }
         fi
         # Brief backoff so multi-contender reaping isn't a tight CPU spin
         # (fractional sleep is non-POSIX; fall back to a whole second).

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -114,6 +114,8 @@ acquire_sync_lock() {
                 return 1
             fi
             SYNC_LOCK_HELD=1
+            # EXIT only, deliberately: a signal death that skips the trap
+            # leaves a dead-PID lock, which the evidence-based reap clears.
             trap release_sync_lock EXIT
             return 0
         fi
@@ -127,8 +129,9 @@ acquire_sync_lock() {
         [ -e "$LOCK_DIR" ] || continue
         if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
             # Live owner wins — unless the lock mtime is ancient: a running
-            # sync heartbeats every batch, so 30+ idle minutes means the PID
-            # was recycled by an unrelated process (kill -0 lies alive).
+            # sync heartbeats every full batch (bounded well under 30 min),
+            # so 30+ idle minutes means the PID was recycled by an unrelated
+            # process (kill -0 lies alive).
             if [ -z "$(find "$LOCK_DIR" -maxdepth 0 -mmin +30 2>/dev/null)" ]; then
                 [ -e "$LOCK_DIR" ] || continue  # vanished mid-check
                 return 1
@@ -149,6 +152,9 @@ acquire_sync_lock() {
         if mv "$LOCK_DIR" "$LOCK_DIR.reap.$$" 2>/dev/null; then
             rm -rf "$LOCK_DIR.reap.$$"
         fi
+        # Brief backoff so multi-contender reaping isn't a tight CPU spin
+        # (fractional sleep is non-POSIX; fall back to a whole second).
+        sleep 0.1 2>/dev/null || sleep 1
     done
     return 1
 }
@@ -304,9 +310,11 @@ cmd_sync() {
         if [ "$running" -ge "$PARALLEL" ]; then
             wait
             running=0
-            # Heartbeat for the recycled-PID backstop. Dir-guarded: after a
-            # lock removal races us, an unguarded touch would recreate the
-            # path as a plain FILE and poison future acquisitions.
+            # Heartbeat (each FULL batch; the final partial batch goes
+            # without, bounded by --max-time far below the 30-min backstop)
+            # for the recycled-PID reap. Dir-guarded: after a lock removal
+            # races us, an unguarded touch would recreate the path as a
+            # plain FILE and poison future acquisitions.
             [ -d "$LOCK_DIR" ] && touch "$LOCK_DIR" 2>/dev/null
         fi
     done < "$pending"

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -109,9 +109,11 @@ acquire_sync_lock() {
             if ! { echo "$$" > "$LOCK_DIR/pid"; } 2>/dev/null; then
                 # Ownership not recorded (disk full?): a pidless lock can
                 # never pass release's cat-guard and invites a live-owner
-                # reap after a minute — back out and defer instead.
+                # reap after a minute — back out. Distinct rc: this is an
+                # error, not contention, and the caller must not report it
+                # as "another sync is already running".
                 rm -rf "$LOCK_DIR"
-                return 1
+                return 2
             fi
             SYNC_LOCK_HELD=1
             # EXIT only, deliberately: a signal death that skips the trap
@@ -275,10 +277,15 @@ cmd_sync() {
     fi
 
     ensure_dirs
-    if ! acquire_sync_lock; then
-        echo "fetch-docs: another sync is already running (lock: $LOCK_DIR)"
-        return 0
-    fi
+    acquire_sync_lock
+    case $? in
+        1)  # contention: someone else is (or appears to be) syncing — benign
+            echo "fetch-docs: another sync is already running (lock: $LOCK_DIR)"
+            return 0 ;;
+        2)  # backout: lock init failed (disk full?) — an error, not contention
+            echo "fetch-docs: could not record sync-lock ownership (disk full?) — sync skipped" >&2
+            return 1 ;;
+    esac
     local pending; pending=$(mktemp)
     # Only pages with a real sha256 are syncable (failed pages have null).
     jq -r '.pages[] | select(.sha256 != null) | [.filename, .md_url, .sha256] | @tsv' "$MANIFEST" \

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -88,6 +88,8 @@ ensure_dirs() { mkdir -p "$CACHE_DIR" "$META_DIR"; }
 # Reaping is evidence-based, never blind-mtime — the old hook-side 30-minute
 # reaper could steal the lock from a legitimately slow first sync, and its
 # unconditional EXIT trap then removed the successor's lock, cascading.
+# Assumes a local filesystem on a single host: mkdir atomicity and kill -0
+# PID checks are not meaningful across NFS/shared caches.
 LOCK_DIR="$CACHE_DIR/.sync.lock"
 SYNC_LOCK_HELD=0
 
@@ -331,12 +333,13 @@ cmd_sync() {
         if [ "$running" -ge "$PARALLEL" ]; then
             wait
             running=0
-            # Heartbeat (each FULL batch; the final partial batch — including
-            # a whole sync that fits in one batch — goes without, bounded by
-            # --max-time far below the 30-min backstop)
-            # for the recycled-PID reap. Dir-guarded: after a lock removal
-            # races us, an unguarded touch would recreate the path as a
-            # plain FILE and poison future acquisitions.
+            # Heartbeat for the recycled-PID reap, fired after each FULL
+            # batch. The final partial batch (or a whole sync that fits in
+            # one batch) goes without — safe, since a batch is bounded by
+            # curl --max-time, far below the 30-min backstop. Dir-guarded:
+            # after a lock removal races us, an unguarded touch would
+            # recreate the path as a plain FILE and poison future
+            # acquisitions.
             [ -d "$LOCK_DIR" ] && touch "$LOCK_DIR" 2>/dev/null
         fi
     done < "$pending"

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -100,7 +100,9 @@ release_sync_lock() {
     fi
 }
 
-# 0 = acquired (release trap installed); 1 = another sync owns the cache.
+# 0 = acquired (release trap installed); 1 = another sync owns the cache;
+# 2 = backout, ownership could not be recorded (disk full?) — an error the
+# caller must not report as contention.
 acquire_sync_lock() {
     local attempts=0 pid
     while [ "$attempts" -lt 10 ]; do  # spin cap: livelock insurance, never hit in practice

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -79,6 +79,61 @@ sha256_of() {
 
 ensure_dirs() { mkdir -p "$CACHE_DIR" "$META_DIR"; }
 
+# --------------------------------------------------------------------------
+# sync lock (issue #28)
+# --------------------------------------------------------------------------
+# One sync per cache, whichever the caller (SessionStart hook, direct CLI,
+# --background child): mkdir is the atomic gate, the owner's PID lives in
+# $LOCK_DIR/pid, and a running sync heartbeats the lock mtime every batch.
+# Reaping is evidence-based, never blind-mtime — the old hook-side 30-minute
+# reaper could steal the lock from a legitimately slow first sync, and its
+# unconditional EXIT trap then removed the successor's lock, cascading.
+LOCK_DIR="$CACHE_DIR/.sync.lock"
+SYNC_LOCK_HELD=0
+
+release_sync_lock() {
+    [ "$SYNC_LOCK_HELD" = 1 ] || return 0
+    # Remove only a lock we still own: if a reaper replaced it, rmdir'ing the
+    # successor's lock here is exactly the #28 cascade.
+    if [ "$(cat "$LOCK_DIR/pid" 2>/dev/null)" = "$$" ]; then
+        rm -rf "$LOCK_DIR"
+    fi
+}
+
+# 0 = acquired (release trap installed); 1 = another sync owns the cache.
+acquire_sync_lock() {
+    local tries=0 pid
+    while :; do
+        if mkdir "$LOCK_DIR" 2>/dev/null; then
+            echo "$$" > "$LOCK_DIR/pid"
+            SYNC_LOCK_HELD=1
+            trap release_sync_lock EXIT
+            return 0
+        fi
+        pid=$(cat "$LOCK_DIR/pid" 2>/dev/null)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            # Live owner wins — unless the lock mtime is ancient: a running
+            # sync heartbeats every batch, so 30+ idle minutes means the PID
+            # was recycled by an unrelated process (kill -0 lies alive).
+            [ -n "$(find "$LOCK_DIR" -maxdepth 0 -mmin +30 2>/dev/null)" ] || return 1
+        elif [ -z "$pid" ]; then
+            # Pidless: the owner may be inside its mkdir->pid-write window.
+            # Fresh (<1 min) = treat as live; older = crashed mid-acquire.
+            [ -n "$(find "$LOCK_DIR" -maxdepth 0 -mmin +1 2>/dev/null)" ] || return 1
+        fi
+        # Stale by evidence (dead PID / recycled-PID backstop / old pidless).
+        # Reap via rename: only one contender wins the mv, losers loop and
+        # re-evaluate the fresh lock. ponytail: the read->mv gap is a
+        # microsecond TOCTOU; worst case is one duplicate sync writing
+        # atomically to the same cache, not corruption or lock loss.
+        [ "$tries" -lt 2 ] || return 1
+        tries=$((tries + 1))
+        if mv "$LOCK_DIR" "$LOCK_DIR.reap.$$" 2>/dev/null; then
+            rm -rf "$LOCK_DIR.reap.$$"
+        fi
+    done
+}
+
 # Fetch a URL to a file with one retry. Returns 0 on success.
 fetch_url() {
     local url="$1" out="$2"
@@ -195,6 +250,10 @@ cmd_sync() {
     fi
 
     ensure_dirs
+    if ! acquire_sync_lock; then
+        echo "fetch-docs: another sync is already running (lock: $LOCK_DIR)"
+        return 0
+    fi
     local pending; pending=$(mktemp)
     # Only pages with a real sha256 are syncable (failed pages have null).
     jq -r '.pages[] | select(.sha256 != null) | [.filename, .md_url, .sha256] | @tsv' "$MANIFEST" \
@@ -226,6 +285,7 @@ cmd_sync() {
         if [ "$running" -ge "$PARALLEL" ]; then
             wait
             running=0
+            touch "$LOCK_DIR" 2>/dev/null  # heartbeat for the recycled-PID backstop
         fi
     done < "$pending"
     wait

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -148,7 +148,7 @@ acquire_sync_lock() {
         fi
         # Stale by evidence (dead PID / recycled-PID backstop / old pidless).
         # Reap via rename: only one contender wins the mv, losers loop and
-        # re-evaluate the fresh lock. ponytail: the read->mv gap is a
+        # re-evaluate the fresh lock. Known ceiling: the read->mv gap is a
         # microsecond TOCTOU; worst case is one duplicate sync writing
         # atomically to the same cache, not corruption or lock loss.
         if mv "$LOCK_DIR" "$LOCK_DIR.reap.$$" 2>/dev/null; then

--- a/plugin/scripts/fetch-docs.sh
+++ b/plugin/scripts/fetch-docs.sh
@@ -102,36 +102,55 @@ release_sync_lock() {
 
 # 0 = acquired (release trap installed); 1 = another sync owns the cache.
 acquire_sync_lock() {
-    local tries=0 pid
-    while :; do
+    local attempts=0 pid
+    while [ "$attempts" -lt 10 ]; do  # spin cap: livelock insurance, never hit in practice
+        attempts=$((attempts + 1))
         if mkdir "$LOCK_DIR" 2>/dev/null; then
-            echo "$$" > "$LOCK_DIR/pid"
+            if ! { echo "$$" > "$LOCK_DIR/pid"; } 2>/dev/null; then
+                # Ownership not recorded (disk full?): a pidless lock can
+                # never pass release's cat-guard and invites a live-owner
+                # reap after a minute — back out and defer instead.
+                rm -rf "$LOCK_DIR"
+                return 1
+            fi
             SYNC_LOCK_HELD=1
             trap release_sync_lock EXIT
             return 0
         fi
         pid=$(cat "$LOCK_DIR/pid" 2>/dev/null)
+        # Lock vanished between the failed mkdir and the read (owner released,
+        # or a contender's reap landed): retry the mkdir — returning 1 here
+        # would skip the sync on a false "already running". -e, not -d: a
+        # plain FILE at the lock path (a heartbeat touch racing a lock
+        # removal) must fall through to the staleness checks and the mv reap
+        # below (both handle files), or it poisons every future sync.
+        [ -e "$LOCK_DIR" ] || continue
         if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
             # Live owner wins — unless the lock mtime is ancient: a running
             # sync heartbeats every batch, so 30+ idle minutes means the PID
             # was recycled by an unrelated process (kill -0 lies alive).
-            [ -n "$(find "$LOCK_DIR" -maxdepth 0 -mmin +30 2>/dev/null)" ] || return 1
+            if [ -z "$(find "$LOCK_DIR" -maxdepth 0 -mmin +30 2>/dev/null)" ]; then
+                [ -e "$LOCK_DIR" ] || continue  # vanished mid-check
+                return 1
+            fi
         elif [ -z "$pid" ]; then
             # Pidless: the owner may be inside its mkdir->pid-write window.
             # Fresh (<1 min) = treat as live; older = crashed mid-acquire.
-            [ -n "$(find "$LOCK_DIR" -maxdepth 0 -mmin +1 2>/dev/null)" ] || return 1
+            if [ -z "$(find "$LOCK_DIR" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+                [ -e "$LOCK_DIR" ] || continue  # vanished mid-check
+                return 1
+            fi
         fi
         # Stale by evidence (dead PID / recycled-PID backstop / old pidless).
         # Reap via rename: only one contender wins the mv, losers loop and
         # re-evaluate the fresh lock. ponytail: the read->mv gap is a
         # microsecond TOCTOU; worst case is one duplicate sync writing
         # atomically to the same cache, not corruption or lock loss.
-        [ "$tries" -lt 2 ] || return 1
-        tries=$((tries + 1))
         if mv "$LOCK_DIR" "$LOCK_DIR.reap.$$" 2>/dev/null; then
             rm -rf "$LOCK_DIR.reap.$$"
         fi
     done
+    return 1
 }
 
 # Fetch a URL to a file with one retry. Returns 0 on success.
@@ -285,7 +304,10 @@ cmd_sync() {
         if [ "$running" -ge "$PARALLEL" ]; then
             wait
             running=0
-            touch "$LOCK_DIR" 2>/dev/null  # heartbeat for the recycled-PID backstop
+            # Heartbeat for the recycled-PID backstop. Dir-guarded: after a
+            # lock removal races us, an unguarded touch would recreate the
+            # path as a plain FILE and poison future acquisitions.
+            [ -d "$LOCK_DIR" ] && touch "$LOCK_DIR" 2>/dev/null
         fi
     done < "$pending"
     wait

--- a/tests/unit/test_fetch_docs_sh.py
+++ b/tests/unit/test_fetch_docs_sh.py
@@ -285,6 +285,11 @@ class TestSyncLock:
             ["bash", "-c", f'umask 0777; exec "{FETCH}" sync'],
             env=env, capture_output=True, text=True,
         )
+        # ensure_dirs ran under umask 0777: reopen the 000-perm .meta so
+        # pytest's tmpdir teardown can remove it (same BSD/GNU rm issue).
+        meta = cache / ".meta"
+        if meta.exists():
+            meta.chmod(0o700)
         assert r.returncode != 0
         assert "already running" not in r.stdout + r.stderr
         assert "sync-lock ownership" in r.stderr, r.stderr

--- a/tests/unit/test_fetch_docs_sh.py
+++ b/tests/unit/test_fetch_docs_sh.py
@@ -274,6 +274,34 @@ class TestSyncLock:
         assert r.returncode == 0, r.stderr
         assert not self.lock_dir(cache).exists()
 
+    def test_concurrent_syncs_exactly_one_wins(self, harness):
+        # Two real cmd_sync invocations racing the actual mkdir gate (not a
+        # fabricated lock): the winner holds through a sentinel-blocked fetch
+        # while the loser defers against the live lock; the winner completes.
+        env, cache, manifest_path = harness
+        env = dict(env)
+        block = manifest_path.parent / "curl.block2"
+        block.write_text("")
+        env["CURL_BLOCK_FILE"] = str(block)
+        a = subprocess.Popen([str(FETCH), "sync"], env=env,
+                             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                             text=True)
+        lock = self.lock_dir(cache)
+        deadline = time.time() + 10
+        while time.time() < deadline and not (lock / "pid").exists():
+            time.sleep(0.02)
+        assert (lock / "pid").exists(), "winner never took the lock"
+        rb = run(env, "sync")  # loser: real acquire path against the live winner
+        assert rb.returncode == 0
+        assert "already running" in rb.stdout, rb.stdout
+        block.unlink()
+        out, _ = a.communicate(timeout=60)
+        assert a.returncode == 0
+        assert "sync complete" in out, out
+        for fn in list(PAGES) + [STALE[0]]:
+            assert (cache / fn).exists(), fn
+        assert not lock.exists()
+
     def test_pid_write_failure_reports_distinct_error(self, harness):
         # Disk-full backout must not masquerade as lock contention: umask 0777
         # makes mkdir create the lock dir unwritable, so the pid write fails

--- a/tests/unit/test_fetch_docs_sh.py
+++ b/tests/unit/test_fetch_docs_sh.py
@@ -274,6 +274,22 @@ class TestSyncLock:
         assert r.returncode == 0, r.stderr
         assert not self.lock_dir(cache).exists()
 
+    def test_pid_write_failure_reports_distinct_error(self, harness):
+        # Disk-full backout must not masquerade as lock contention: umask 0777
+        # makes mkdir create the lock dir unwritable, so the pid write fails
+        # and the acquire backs out — the message must say so, not "another
+        # sync is already running", and the exit code must be nonzero.
+        env, cache, _ = harness
+        cache.mkdir(parents=True, exist_ok=True)
+        r = subprocess.run(
+            ["bash", "-c", f'umask 0777; exec "{FETCH}" sync'],
+            env=env, capture_output=True, text=True,
+        )
+        assert r.returncode != 0
+        assert "already running" not in r.stdout + r.stderr
+        assert "sync-lock ownership" in r.stderr, r.stderr
+        assert not self.lock_dir(cache).exists()  # backed out cleanly
+
     def test_fetch_line_child_does_not_release_parent_lock(self, harness):
         # The sync job pool re-invokes self as __fetch_line children; they
         # never install the release trap, so a child exiting must leave the

--- a/tests/unit/test_fetch_docs_sh.py
+++ b/tests/unit/test_fetch_docs_sh.py
@@ -5,6 +5,7 @@ import json
 import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -38,7 +39,8 @@ INSECURE = ("insecure.md", "http://code.claude.com/docs/en/insecure.md", "# Inse
 RAWEVIL = ("rawevil.md", "https://raw.githubusercontent.com/anthropics/claude-code/../../attacker/evil/main/x.md", "# RawEvil\n")
 
 FAKE_CURL = r'''#!/usr/bin/env python3
-import sys, os, json
+import sys, os, json, time
+time.sleep(float(os.environ.get("CURL_SLEEP", "0")))
 args = sys.argv[1:]
 out = None; url = None
 i = 0
@@ -170,6 +172,96 @@ class TestSync:
         run(env, "sync")
         meta = json.loads((cache / ".meta" / "claude-code__hooks.md.json").read_text())
         assert meta["stale_manifest"] is False
+
+
+class TestSyncLock:
+    """Issue #28: cmd_sync must lock (every caller), reap only dead owners,
+    and never remove a lock it no longer owns (the EXIT-trap cascade)."""
+
+    @staticmethod
+    def lock_dir(cache: Path) -> Path:
+        return cache / ".sync.lock"
+
+    def make_lock(self, cache: Path, pid=None, age_secs=0):
+        cache.mkdir(parents=True, exist_ok=True)
+        lock = self.lock_dir(cache)
+        lock.mkdir()
+        if pid is not None:
+            (lock / "pid").write_text(f"{pid}\n")
+        if age_secs:
+            old = time.time() - age_secs
+            os.utime(lock, (old, old))
+        return lock
+
+    def test_sync_defers_when_lock_held_by_live_process(self, harness):
+        env, cache, _ = harness
+        self.make_lock(cache, pid=os.getpid())  # pytest itself: definitely alive
+        r = run(env, "sync")
+        assert r.returncode == 0, r.stderr
+        assert "already running" in r.stdout, r.stdout
+        assert not list(cache.glob("*.md"))  # nothing fetched
+        assert self.lock_dir(cache).is_dir()  # foreign lock untouched
+
+    def test_sync_defers_on_fresh_pidless_lock(self, harness):
+        # A pidless lock can be an owner inside its mkdir->pid-write window:
+        # fresh means live, do not reap.
+        env, cache, _ = harness
+        self.make_lock(cache)
+        r = run(env, "sync")
+        assert r.returncode == 0, r.stderr
+        assert "already running" in r.stdout, r.stdout
+        assert not list(cache.glob("*.md"))
+        assert self.lock_dir(cache).is_dir()
+
+    def test_sync_reaps_dead_owner_lock(self, harness):
+        env, cache, _ = harness
+        p = subprocess.Popen(["true"], stdout=subprocess.DEVNULL)
+        p.wait()  # reaped: kill -0 on this pid now fails
+        self.make_lock(cache, pid=p.pid)
+        r = run(env, "sync")
+        assert r.returncode == 0, r.stderr
+        for fn in list(PAGES) + [STALE[0]]:
+            assert (cache / fn).exists(), fn
+        assert not self.lock_dir(cache).exists()  # released its own lock
+
+    def test_sync_reaps_ancient_lock_despite_live_pid(self, harness):
+        # Recycled-PID backstop: a live sync refreshes the lock mtime every
+        # batch, so a lock untouched for 30+ minutes belongs to no live sync
+        # even when kill -0 says otherwise.
+        env, cache, _ = harness
+        self.make_lock(cache, pid=os.getpid(), age_secs=3600)
+        r = run(env, "sync")
+        assert r.returncode == 0, r.stderr
+        for fn in list(PAGES) + [STALE[0]]:
+            assert (cache / fn).exists(), fn
+        assert not self.lock_dir(cache).exists()
+
+    def test_sync_removes_own_lock_on_completion(self, harness):
+        env, cache, _ = harness
+        r = run(env, "sync")
+        assert r.returncode == 0, r.stderr
+        assert not self.lock_dir(cache).exists()
+
+    def test_finishing_sync_leaves_stolen_lock_alone(self, harness):
+        # The #28 cascade: sync A's EXIT trap must not rmdir a lock that was
+        # (wrongly or rightly) reaped and re-acquired by a successor.
+        env, cache, _ = harness
+        env = dict(env)
+        env["CURL_SLEEP"] = "1"
+        env["CLAUDE_DOCS_PARALLEL"] = "1"  # 4 syncable pages -> >=4s of fetching
+        a = subprocess.Popen([str(FETCH), "sync"], env=env,
+                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        lock = self.lock_dir(cache)
+        deadline = time.time() + 10
+        while time.time() < deadline and not (lock / "pid").exists():
+            time.sleep(0.05)
+        assert (lock / "pid").exists(), "sync A never took the lock"
+        # Steal the lock mid-sync (simulates the mtime reaper of a second session).
+        shutil.rmtree(lock)
+        self.make_lock(cache, pid=os.getpid())
+        a.wait(timeout=60)
+        assert lock.is_dir(), "finishing sync removed a lock it no longer owns"
+        assert (lock / "pid").read_text().strip() == str(os.getpid())
 
 
 class TestGet:

--- a/tests/unit/test_fetch_docs_sh.py
+++ b/tests/unit/test_fetch_docs_sh.py
@@ -274,6 +274,19 @@ class TestSyncLock:
         assert r.returncode == 0, r.stderr
         assert not self.lock_dir(cache).exists()
 
+    def test_fetch_line_child_does_not_release_parent_lock(self, harness):
+        # The sync job pool re-invokes self as __fetch_line children; they
+        # never install the release trap, so a child exiting must leave the
+        # parent's lock alone — load-bearing for the cascade fix.
+        env, cache, _ = harness
+        lock = self.make_lock(cache, pid=os.getpid())
+        url, content = PAGES["claude-code__hooks.md"]
+        line = f"claude-code__hooks.md\t{url}\t{sha(content)}"
+        r = run(env, "__fetch_line", line)
+        assert r.returncode == 0, r.stderr
+        assert (cache / "claude-code__hooks.md").exists()
+        assert lock.is_dir() and (lock / "pid").exists()
+
     def test_finishing_sync_leaves_stolen_lock_alone(self, harness):
         # The #28 cascade: sync A's EXIT trap must not rmdir a lock that was
         # (wrongly or rightly) reaped and re-acquired by a successor. The

--- a/tests/unit/test_fetch_docs_sh.py
+++ b/tests/unit/test_fetch_docs_sh.py
@@ -40,7 +40,10 @@ RAWEVIL = ("rawevil.md", "https://raw.githubusercontent.com/anthropics/claude-co
 
 FAKE_CURL = r'''#!/usr/bin/env python3
 import sys, os, json, time
-time.sleep(float(os.environ.get("CURL_SLEEP", "0")))
+# Deterministic hold-open: block while the sentinel file exists (lock tests).
+_blk = os.environ.get("CURL_BLOCK_FILE", "")
+while _blk and os.path.exists(_blk):
+    time.sleep(0.02)
 args = sys.argv[1:]
 out = None; url = None
 i = 0
@@ -236,6 +239,35 @@ class TestSyncLock:
             assert (cache / fn).exists(), fn
         assert not self.lock_dir(cache).exists()
 
+    def test_sync_reaps_stale_plain_file_at_lock_path(self, harness):
+        # Poison-file regression: a heartbeat racing a lock removal can leave
+        # a plain FILE at the lock path. Treating non-dir as "vanished"
+        # forever would silently disable sync permanently — a stale file must
+        # be reaped like any stale lock.
+        env, cache, _ = harness
+        cache.mkdir(parents=True, exist_ok=True)
+        poison = self.lock_dir(cache)
+        poison.write_text("")
+        old = time.time() - 7200
+        os.utime(poison, (old, old))
+        r = run(env, "sync")
+        assert r.returncode == 0, r.stderr
+        for fn in list(PAGES) + [STALE[0]]:
+            assert (cache / fn).exists(), fn
+        assert not poison.exists()
+
+    def test_sync_defers_on_fresh_plain_file_at_lock_path(self, harness):
+        # Fresh non-dir obstruction: same grace as a fresh pidless lock.
+        env, cache, _ = harness
+        cache.mkdir(parents=True, exist_ok=True)
+        poison = self.lock_dir(cache)
+        poison.write_text("")
+        r = run(env, "sync")
+        assert r.returncode == 0, r.stderr
+        assert "already running" in r.stdout, r.stdout
+        assert not list(cache.glob("*.md"))
+        assert poison.exists()
+
     def test_sync_removes_own_lock_on_completion(self, harness):
         env, cache, _ = harness
         r = run(env, "sync")
@@ -244,21 +276,25 @@ class TestSyncLock:
 
     def test_finishing_sync_leaves_stolen_lock_alone(self, harness):
         # The #28 cascade: sync A's EXIT trap must not rmdir a lock that was
-        # (wrongly or rightly) reaped and re-acquired by a successor.
-        env, cache, _ = harness
+        # (wrongly or rightly) reaped and re-acquired by a successor. The
+        # fake curl blocks on a sentinel file, so the steal happens inside a
+        # deterministically held-open window (no sleeps, no timing).
+        env, cache, manifest_path = harness
         env = dict(env)
-        env["CURL_SLEEP"] = "1"
-        env["CLAUDE_DOCS_PARALLEL"] = "1"  # 4 syncable pages -> >=4s of fetching
+        block = manifest_path.parent / "curl.block"
+        block.write_text("")
+        env["CURL_BLOCK_FILE"] = str(block)
         a = subprocess.Popen([str(FETCH), "sync"], env=env,
                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         lock = self.lock_dir(cache)
         deadline = time.time() + 10
         while time.time() < deadline and not (lock / "pid").exists():
-            time.sleep(0.05)
+            time.sleep(0.02)
         assert (lock / "pid").exists(), "sync A never took the lock"
         # Steal the lock mid-sync (simulates the mtime reaper of a second session).
         shutil.rmtree(lock)
         self.make_lock(cache, pid=os.getpid())
+        block.unlink()  # release the held-open fetches; A finishes
         a.wait(timeout=60)
         assert lock.is_dir(), "finishing sync removed a lock it no longer owns"
         assert (lock / "pid").read_text().strip() == str(os.getpid())

--- a/tests/unit/test_sync_docs_sh.py
+++ b/tests/unit/test_sync_docs_sh.py
@@ -110,10 +110,34 @@ class TestSyncLockDelegation:
         run_hook(home, origin)
         legacy = home / ".claude-code-docs" / ".sync.lock"
         legacy.mkdir()  # hook-era lock: bare dir, no pid file
+        old = time.time() - 3600
+        os.utime(legacy, (old, old))  # stale: no pre-#28 session still owns it
         r = run_hook(home, origin)
         assert r.returncode == 0
         assert "Syncing changed pages" in context_of(r), context_of(r)
         assert not legacy.exists()
+
+    def test_hook_preserves_fresh_legacy_lock(self, tmp_path, origin):
+        """A FRESH hook-era lock may belong to a still-running pre-#28
+        session's sync child — blind removal would double-sync during the
+        upgrade window. The new-caller sync still launches (its own lock is
+        elsewhere), but the legacy dir is left alone until stale."""
+        home = tmp_path / "home"
+        home.mkdir()
+        scripts = origin / "plugin" / "scripts"
+        scripts.mkdir(parents=True)
+        stub = scripts / "fetch-docs.sh"
+        stub.write_text("#!/bin/bash\nexit 0\n")
+        stub.chmod(0o755)
+        _git("add", ".", cwd=origin)
+        _git("commit", "-qm", "stub fetch script", cwd=origin)
+        run_hook(home, origin)
+        legacy = home / ".claude-code-docs" / ".sync.lock"
+        legacy.mkdir()  # fresh: possibly live pre-#28 owner
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert "Syncing changed pages" in context_of(r), context_of(r)
+        assert legacy.is_dir()
 
 
 class TestRepoUrlSentinel:
@@ -368,6 +392,26 @@ class TestOrphanPrune:
         run_hook(home, origin)
         docs = home / ".claude-code-docs"
         (docs / "cache").mkdir()  # empty — recreated by a racing background fetch
+        orphan = home / ".claude-code-docs.new.4194301"
+        (orphan / "cache").mkdir(parents=True)
+        (orphan / "cache" / "page.md").write_text("full corpus")
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert (docs / "cache" / "page.md").read_text() == "full corpus"
+        assert not orphan.exists()
+
+    def test_scaffold_only_recreated_cache_does_not_block_rescue(self, tmp_path, origin):
+        """Issue #28 review: a racing sync child recreates cache/ with .meta/
+        and .sync.lock/ scaffolding (ensure_dirs runs before the lock gate) —
+        never with a bare empty dir. Scaffolding-only cache must still count
+        as empty, or a populated parked corpus is silently discarded."""
+        home = tmp_path / "home"
+        home.mkdir()
+        run_hook(home, origin)
+        docs = home / ".claude-code-docs"
+        (docs / "cache" / ".meta").mkdir(parents=True)  # ensure_dirs artifact
+        (docs / "cache" / ".sync.lock").mkdir()
+        (docs / "cache" / ".sync.lock" / "pid").write_text("4194302\n")
         orphan = home / ".claude-code-docs.new.4194301"
         (orphan / "cache").mkdir(parents=True)
         (orphan / "cache" / "page.md").write_text("full corpus")

--- a/tests/unit/test_sync_docs_sh.py
+++ b/tests/unit/test_sync_docs_sh.py
@@ -91,6 +91,31 @@ class TestFirstRunAndUpdate:
         assert "up-to-date" in context_of(r) or "updated" in context_of(r)
 
 
+class TestSyncLockDelegation:
+    def test_hook_cleans_legacy_lock_and_still_syncs(self, tmp_path, origin):
+        """Issue #28: locking moved into fetch-docs.sh cmd_sync. The hook no
+        longer takes its own lock — a leftover hook-era .sync.lock (bare dir)
+        must be cleaned up and must not suppress the background sync."""
+        home = tmp_path / "home"
+        home.mkdir()
+        # The fixture origin has no plugin/; ship a stub fetch-docs.sh so the
+        # hook's [ -x "$FETCH" ] gate passes and the launch path is exercised.
+        scripts = origin / "plugin" / "scripts"
+        scripts.mkdir(parents=True)
+        stub = scripts / "fetch-docs.sh"
+        stub.write_text("#!/bin/bash\nexit 0\n")
+        stub.chmod(0o755)
+        _git("add", ".", cwd=origin)
+        _git("commit", "-qm", "stub fetch script", cwd=origin)
+        run_hook(home, origin)
+        legacy = home / ".claude-code-docs" / ".sync.lock"
+        legacy.mkdir()  # hook-era lock: bare dir, no pid file
+        r = run_hook(home, origin)
+        assert r.returncode == 0
+        assert "Syncing changed pages" in context_of(r), context_of(r)
+        assert not legacy.exists()
+
+
 class TestRepoUrlSentinel:
     def test_override_ignored_without_sentinel(self, tmp_path, origin):
         """A stray CLAUDE_DOCS_REPO_URL alone must never repoint a real install."""


### PR DESCRIPTION
Fixes #28.

## Problem

Three linked defects in the background-sync lock (from the v2.0.1 review, deferred as M4):

1. The lock in `plugin/hooks/sync-docs.sh` guarded only the hook's call path — direct `fetch-docs.sh sync` / `sync --background` ran unlocked.
2. The blind 30-minute mtime reaper could steal the lock from a legitimately long first sync (725 pages on a slow link exceeds 30 min with the batch-barrier pool), starting a second full sync in parallel.
3. When the first sync exited, its EXIT trap `rmdir`'d the *successor's* lock, letting a third stack — the guard defeated itself in cascade.

## Fix

Lock acquisition moved inside `cmd_sync` in `fetch-docs.sh`, covering every caller:

- **Atomic gate**: `mkdir cache/.sync.lock`, owner PID stored in `.sync.lock/pid`, lock mtime heartbeated every fetch batch.
- **Evidence-based reap** (never blind mtime): dead owner PID; pidless lock older than 1 min (crashed mid-acquire); or 30-min-idle mtime despite a "live" PID (recycled-PID backstop — `kill -0` can lie). Reap goes through `mv`-aside so two contenders can't double-reap; a stale plain file at the lock path is reaped the same way.
- **Owner-checked release**: the EXIT trap removes the lock only while `pid` still matches `$$` — a reaped-and-reacquired lock is never removed by the previous owner (the cascade).
- The hook delegates locking entirely and removes the legacy `$DOCS_DIR/.sync.lock` only when stale (a fresh one may belong to a live pre-#28 session's child during the upgrade window).
- `rescue_user_data` now treats a cache holding only sync scaffolding (empty `.meta/`, `.sync.lock/`) as empty, so a racing sync child can no longer defeat rescue of a populated parked corpus.
- Checked pid write (disk-full backs out cleanly instead of holding an unreleasable pidless lock); dir-guarded heartbeat (can't recreate a removed lock path as a poison file).

ARCHITECTURE.md documents the lock in the client layout and fetch-layer sections.

## Tests

9 new tests (TDD — each watched failing first): lock defer on live owner / fresh pidless / fresh plain file; evidence reaps (dead PID, ancient-despite-live-PID, stale plain file); own-lock release; a deterministic stolen-lock cascade regression (fake curl held open via sentinel file — 0.2s, no sleeps); hook-side legacy-lock staleness both directions; scaffold-only recreated cache no longer blocks rescue. Suite: 190 passed, shellcheck clean.

Verified by two adversarial verifier rounds (the first caught a real poison-file regression in the review round — a heartbeat racing a lock removal recreated the path as a plain file and permanently disabled sync; fixed + pinned by test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJqWbd5r7AigcYTJFPi2Ve
