### PR TITLE
docs: audit fixes — pytest provisioning, label convergence, safeguard wording

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Generate coverage
         run: |
-          pytest tests/ -v --cov=scripts --cov-report=html --cov-report=term --cov-report=xml -m "not slow and not network"
+          pytest tests/ -v --cov=scripts --cov-report=html --cov-report=term --cov-report=xml
 
       - name: Check coverage threshold (50%)
         run: |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,7 +80,7 @@ stored — a consumer recomputes `slugify(text)` on demand.
 |---|---|---|
 | `MIN_DISCOVERY_THRESHOLD` | 200 | abort if discovery finds fewer pages |
 | `MAX_DELETION_PERCENT` | 10 | abort if a manifest transition drops >10% of entries |
-| `MIN_EXPECTED_FILES` | 250 | abort if the new manifest has fewer pages |
+| `MIN_EXPECTED_FILES` | 250 | abort if fewer pages were fetched OK *this run* (changelog excluded); the workflow's jq check separately floors total manifest pages |
 
 `validate_manifest_transition(old, new)` is first-run-safe: no v2 predecessor counts
 as a clean start, not a mass removal. `update-docs.yml` repeats the floor check in jq.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,5 +77,5 @@ python3 scripts/build_search_index.py                     # build search_index.j
 ./plugin/skills/claude-docs/scripts/fuzzy-search.sh agent sdk python
 ./plugin/skills/claude-docs-validate/scripts/validate-paths.sh --quick
 
-uv run pytest tests/ -q -m "not network"
+uv run pytest tests/ -q
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ uv run shellcheck --severity=warning plugin/scripts/*.sh plugin/skills/*/scripts
 uv sync --group dev
 
 # Run the test suite (network tests excluded)
-uv run pytest tests/ -q -m "not network"
+uv run pytest tests/ -q
 
 # Regenerate metadata locally: fetch into the gitignored .doc_fetch/ scratch, then build the index
 DOCS_FETCH_LIMIT=8 python3 scripts/fetch_claude_docs.py   # fast preview
@@ -114,7 +114,7 @@ Cache filenames follow the manifest's flattened convention. URLs are stored **ve
 
 ## Testing requirements
 
-- All new Python code needs unit tests; keep the suite green with `uv run pytest tests/ -q -m "not network"`.
+- All new Python code needs unit tests; keep the suite green with `uv run pytest tests/ -q`.
 - Shell scripts are tested via a mocked-curl harness under `tests/unit/` (see `test_fetch_docs_sh.py`) — no live network in unit tests.
 - The stemming rule in `build_search_index.py` (Python) and `content-search.sh` (jq) must stay **identical**; `tests/unit/test_stem_parity.py` enforces it.
 
@@ -122,7 +122,7 @@ Cache filenames follow the manifest's flattened convention. URLs are stored **ve
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`). Before opening a PR:
 
-- [ ] `uv run pytest tests/ -q -m "not network"` is green
+- [ ] `uv run pytest tests/ -q` is green
 - [ ] `shellcheck --severity=warning` is clean (if you touched shell)
 - [ ] No documentation prose is staged (the invariant above)
 - [ ] Relevant docs updated (`README.md`, `CLAUDE.md`, `ARCHITECTURE.md`)

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The `/docs` skill understands intent — ask questions in plain English:
 /docs what are the best practices for Agent SDK in Python?
 /docs explain the differences between hooks and MCP
 /docs how do I configure extended thinking for the API?
-/docs show me all prompt library templates
+/docs show me all Agent SDK pages
 ```
 
 Claude finds the right docs, reads them, and synthesizes a clear answer with source links.

--- a/plugin/skills/claude-docs/SKILL.md
+++ b/plugin/skills/claude-docs/SKILL.md
@@ -101,11 +101,16 @@ When matches span products (CLI + API + Agent SDK), ask which the user means. La
 
 | category | Say to user |
 |---|---|
-| `claude_code` | **Claude Code** |
-| `agent_sdk` | **Agent SDK** |
+| `claude_code` | **Claude Code CLI** |
+| `agent_sdk` | **Claude Agent SDK** |
 | `api_reference` | **Claude API** |
 | `core_documentation` | **Claude Documentation** |
 | `agents_and_tools` | **Agents & Tools** |
+| `about_claude` | **About Claude** |
+| `get_started` | **Getting Started** |
+| `test_and_evaluate` | **Testing & Evaluation** |
+| `release_notes` | **Release Notes** |
+| `resources` | **Resources** |
 | `prompt_library` | **Prompt Library** |
 
 After selection → read all docs in that context and synthesize.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,6 @@ dependencies = [
     "requests>=2.33.0",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-mock>=3.10.0",
-    "pyyaml>=6.0.0",
-]
-
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -32,8 +23,6 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "network: marks tests requiring network access",
     "integration: marks tests as integration tests",
 ]
 addopts = [
@@ -79,7 +68,14 @@ source = [
     "*/work/claude-code-docs/claude-code-docs/scripts/",
 ]
 
+# The single "dev" definition: `uv sync --group dev` must provision everything
+# CLAUDE.md's dev workflow documents, pytest included.
 [dependency-groups]
 dev = [
     "shellcheck-py>=0.11.0.1",
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-mock>=3.10.0",
+    "pyyaml>=6.0.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Pytest configuration and fixtures."""
+"""Pytest configuration and fixtures. Markers are declared in pyproject.toml."""
 
 import pytest
 from pathlib import Path
@@ -8,17 +8,3 @@ from pathlib import Path
 def project_root():
     """Get project root directory."""
     return Path(__file__).parent.parent
-
-
-# Configure pytest
-def pytest_configure(config):
-    """Configure pytest with custom markers."""
-    config.addinivalue_line(
-        "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
-    )
-    config.addinivalue_line(
-        "markers", "network: marks tests requiring network access"
-    )
-    config.addinivalue_line(
-        "markers", "integration: marks tests as integration tests"
-    )


### PR DESCRIPTION
Five approved fixes from an evidence-based docs audit (4 parallel unprimed code explorers + mechanical fact-check of every CLAUDE.md/README claim + cross-file drift diff). Details in the commit message.

Key fix: `uv sync --group dev` now actually provisions `uv run pytest` — verified from a clean resolve (`pytest.__file__` resolves inside .venv, 193 tests pass under the venv interpreter). Everything else is doc/label convergence to code ground truth.

Adversarially verified (clean PASS): fresh-env provisioning proof, strict-markers probe with a deliberately undeclared marker, CI grep for the deleted extra, safeguard-wording vs safeguards.py semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJqWbd5r7AigcYTJFPi2Ve